### PR TITLE
feat: add backend listing and review lookup

### DIFF
--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
@@ -37,6 +37,20 @@ public class ReviewController {
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
+    
+
+    @GetMapping
+    public List<Review> all(@RequestParam(required = false) String search) {
+        if (search == null || search.isBlank()) {
+            return reviewService.getAllReviews();
+        }
+        ReviewSearchCriteria criteria = ReviewSearchCriteria.builder()
+                .productNameContains(search)
+                .build();
+        return reviewService.searchReviews(criteria, PageRequest.of(0, Integer.MAX_VALUE))
+                .getContent();
+    }
+
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable String id) {

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/service/ReviewService.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/service/ReviewService.java
@@ -22,6 +22,10 @@ public class ReviewService {
     private final ReviewRepository reviewRepo;
     private final ReviewHistoryService historyService;
 
+    public List<Review> getAllReviews() {
+        return reviewRepo.findAll();
+    }
+
     // ---------- CRUD ----------
     public Review createReview(Review r) {
         if (r.getRefundAmountRupees() == null && r.getAmountRupees() != null && r.getLessRupees() != null) {

--- a/review-tracker-ui/src/api/reviews.js
+++ b/review-tracker-ui/src/api/reviews.js
@@ -3,6 +3,7 @@ import axios from "axios";
 const API_BASE = "http://localhost:8080/api/reviews"; // adjust backend URL
 
 export const getReviews = (params = {}) => axios.get(API_BASE, { params });
+export const getReview = (id) => axios.get(`${API_BASE}/${id}`);
 export const createReview = (review) => axios.post(API_BASE, review);
 export const updateReview = (id, review) => axios.put(`${API_BASE}/${id}`, review);
 export const deleteReview = (id) => axios.delete(`${API_BASE}/${id}`);

--- a/review-tracker-ui/src/components/ReviewForm.jsx
+++ b/review-tracker-ui/src/components/ReviewForm.jsx
@@ -5,7 +5,7 @@ import { createReview, updateReview } from "../api/reviews";
 import { getPlatforms, getMediators, getStatuses } from "../api/lookups";
 
 export default function ReviewForm({ review, onSuccess }) {
-  const { register, handleSubmit, control, watch, setValue, formState: { errors } } = useForm({
+  const { register, handleSubmit, control, watch, formState: { errors } } = useForm({
     defaultValues: review || {
       orderId: "",
       orderLink: "",
@@ -58,7 +58,8 @@ export default function ReviewForm({ review, onSuccess }) {
         await createReview(data);
       }
       onSuccess?.();
-    } catch (e) {
+    } catch (err) {
+      console.error("Error saving review", err);
       alert("Error saving review");
     }
   };

--- a/review-tracker-ui/src/components/ReviewTable.jsx
+++ b/review-tracker-ui/src/components/ReviewTable.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { getReviews, deleteReview } from "../api/reviews";
 import { useNavigate } from "react-router-dom";
 
@@ -8,11 +8,7 @@ export default function ReviewTable() {
   const [search, setSearch] = useState("");
   const navigate = useNavigate();
 
-  useEffect(() => {
-    loadReviews();
-  }, []);
-
-  const loadReviews = async () => {
+  const loadReviews = useCallback(async () => {
     setLoading(true);
     try {
       const res = await getReviews({ search });
@@ -21,7 +17,11 @@ export default function ReviewTable() {
       console.error("Failed to fetch reviews", err);
     }
     setLoading(false);
-  };
+  }, [search]);
+
+  useEffect(() => {
+    loadReviews();
+  }, [loadReviews]);
 
   const handleDelete = async (id) => {
     if (!window.confirm("Are you sure you want to delete this review?")) return;

--- a/review-tracker-ui/src/pages/Reviews.jsx
+++ b/review-tracker-ui/src/pages/Reviews.jsx
@@ -1,13 +1,14 @@
 import { Routes, Route } from "react-router-dom";
 import ReviewTable from "../components/ReviewTable";
-import ReviewForm from "../components/ReviewForm";
+import AddReview from "./AddReview";
+import EditReview from "./EditReview";
 
 export default function Reviews() {
   return (
     <Routes>
       <Route path="/" element={<ReviewTable />} />
-      <Route path="/new" element={<ReviewForm />} />
-      <Route path="/edit/:id" element={<ReviewForm />} />
+      <Route path="/new" element={<AddReview />} />
+      <Route path="/edit/:id" element={<EditReview />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add service and controller method for listing reviews with optional search
- expose getReview API and route add/edit forms through dedicated pages

## Testing
- `mvn -q -f review-tracker-backend/pom.xml test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af514a0abc83339d5b182837a018b3