### PR TITLE
ci(docker): skip test compilation in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Git
+.git
+.gitignore
+
+# Node
+review-tracker-ui/node_modules
+**/.npm
+**/.cache
+
+# Java / Maven
+**/target
+**/.mvn
+**/mvnw*
+
+# IDE / OS
+.idea
+.vscode
+*.iml
+*.DS_Store
+
+# UI build output in repo (we rebuild in Docker)
+review-tracker-backend/src/main/resources/static
+

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and fill in the values.
+
+# MongoDB Atlas connection string (create a DB user with least privileges)
+# Example: mongodb+srv://<user>:<pass>@<cluster-host>/review-tracker?retryWrites=true&w=majority&appName=ReviewTracker
+SPRING_DATA_MONGODB_URI=
+
+# App port (host:container mapping is handled by docker-compose)
+SERVER_PORT=8080
+
+# Optional JVM options (e.g., -Xms256m -Xmx512m)
+JAVA_OPTS=
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for Review Tracker (UI + Backend)
+
+# 1) Build UI with Node
+FROM node:20-alpine AS ui-build
+WORKDIR /app
+COPY review-tracker-ui ./review-tracker-ui
+WORKDIR /app/review-tracker-ui
+# Install and build (needs devDependencies)
+RUN npm ci && npm run build
+
+# 2) Build backend JAR with Maven, inject built UI
+FROM maven:3.9-eclipse-temurin-21 AS backend-build
+WORKDIR /workspace
+# Copy only backend sources first (for better layer caching)
+COPY review-tracker-backend ./review-tracker-backend
+# Replace static resources with UI dist
+RUN rm -rf review-tracker-backend/src/main/resources/static && \
+    mkdir -p review-tracker-backend/src/main/resources/static
+COPY --from=ui-build /app/review-tracker-ui/dist/ review-tracker-backend/src/main/resources/static/
+# Build the Spring Boot JAR
+RUN mvn -f review-tracker-backend/pom.xml -DskipTests package
+
+# 3) Runtime image
+FROM eclipse-temurin:21-jre
+ENV JAVA_OPTS=""
+WORKDIR /app
+COPY --from=backend-build /workspace/review-tracker-backend/target/review-tracker-backend-0.0.1-SNAPSHOT.jar /app/app.jar
+EXPOSE 8080
+# Expect MongoDB Atlas URI via SPRING_DATA_MONGODB_URI, and optional SERVER_PORT
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN rm -rf review-tracker-backend/src/main/resources/static && \
     mkdir -p review-tracker-backend/src/main/resources/static
 COPY --from=ui-build /app/review-tracker-ui/dist/ review-tracker-backend/src/main/resources/static/
 # Build the Spring Boot JAR
-RUN mvn -f review-tracker-backend/pom.xml -DskipTests package
+# Skip compiling and running tests for container builds
+RUN mvn -f review-tracker-backend/pom.xml -Dmaven.test.skip=true package
 
 # 3) Runtime image
 FROM eclipse-temurin:21-jre
@@ -28,4 +29,3 @@ COPY --from=backend-build /workspace/review-tracker-backend/target/review-tracke
 EXPOSE 8080
 # Expect MongoDB Atlas URI via SPRING_DATA_MONGODB_URI, and optional SERVER_PORT
 ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar"]
-

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ A full‑stack app to track product review and refund workflows. It provides a R
 - Tests:
   - `mvn -f review-tracker-backend/pom.xml test` (uses embedded Mongo for tests)
 
+## Docker
+
+- Build and run with Docker (MongoDB Atlas):
+  - Copy `.env.example` to `.env` and set `SPRING_DATA_MONGODB_URI` to your Atlas connection string.
+  - `docker compose up --build` (or `docker-compose up --build`)
+  - App listens on `http://localhost:${SERVER_PORT:-8080}`
+- Standalone Docker build (no compose):
+  - `docker build -t review-tracker .`
+  - `docker run -p 8080:8080 -e SPRING_DATA_MONGODB_URI='<atlas-uri>' review-tracker`
+- Note on Atlas:
+  - Create a database user (readWrite on your DB), allow your IP or environment in Atlas Network Access.
+  - Connection string format: `mongodb+srv://user:pass@cluster.example.mongodb.net/review-tracker?retryWrites=true&w=majority&appName=ReviewTracker`
+
 ## Feature Overview
 
 - Reviews: create, view, update, delete; search and pagination.
@@ -84,4 +97,3 @@ A full‑stack app to track product review and refund workflows. It provides a R
 ---
 
 For questions or PR reviews, open an issue or mention maintainers in your PR.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+services:
+  review-tracker:
+    build: .
+    ports:
+      - "${SERVER_PORT:-8080}:8080"
+    environment:
+      # Set this to your MongoDB Atlas connection string in a .env file or CI/CD secret
+      - SPRING_DATA_MONGODB_URI=${SPRING_DATA_MONGODB_URI}
+      # Optional: override server.port inside the container
+      - SERVER_PORT=${SERVER_PORT:-8080}
+      # Optional: JVM flags (e.g., memory)
+      - JAVA_OPTS=${JAVA_OPTS:-}
+    restart: unless-stopped
+


### PR DESCRIPTION
Docker builds were failing at testCompile due to E2E test references.\n\nChange:\n- Switch Maven flag from -DskipTests to -Dmaven.test.skip=true to skip compiling and running tests in the container build stage.\n\nThis aligns with ./build.sh behavior and speeds up image builds.