### PR TITLE
ci: add GitHub Actions (build, GHCR publish, optional SSH deploy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Git
+.git
+.gitignore
+
+# Node
+review-tracker-ui/node_modules
+**/.npm
+**/.cache
+
+# Java / Maven
+**/target
+**/.mvn
+**/mvnw*
+
+# IDE / OS
+.idea
+.vscode
+*.iml
+*.DS_Store
+
+# UI build output in repo (we rebuild in Docker)
+review-tracker-backend/src/main/resources/static
+

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and fill in the values.
+
+# MongoDB Atlas connection string (create a DB user with least privileges)
+# Example: mongodb+srv://<user>:<pass>@<cluster-host>/review-tracker?retryWrites=true&w=majority&appName=ReviewTracker
+SPRING_DATA_MONGODB_URI=
+
+# App port (host:container mapping is handled by docker-compose)
+SERVER_PORT=8080
+
+# Optional JVM options (e.g., -Xms256m -Xmx512m)
+JAVA_OPTS=
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Build UI and Backend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install UI deps
+        working-directory: review-tracker-ui
+        run: npm ci
+
+      - name: Lint UI
+        working-directory: review-tracker-ui
+        run: npm run lint --if-present
+
+      - name: Build UI
+        working-directory: review-tracker-ui
+        run: npm run build
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build backend (skip tests for speed)
+        run: mvn -f review-tracker-backend/pom.xml -B -DskipTests package
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-tracker-jar
+          path: review-tracker-backend/target/review-tracker-backend-*.jar
+

--- a/.github/workflows/deploy-ssh.yml
+++ b/.github/workflows/deploy-ssh.yml
@@ -1,0 +1,59 @@
+name: Deploy via SSH (Pull GHCR image)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (e.g., latest or sha)"
+        required: true
+        default: latest
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/review-tracker
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Connect and deploy on remote host
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            echo "Logging in to GHCR"
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+            IMAGE=${{ env.IMAGE_NAME }}:${{ github.event.inputs.image_tag }}
+            echo "Pulling $IMAGE"
+            docker pull "$IMAGE"
+            mkdir -p ~/apps/review-tracker
+            cd ~/apps/review-tracker
+            # Write/update .env for compose
+            cat > .env << EOF
+            SPRING_DATA_MONGODB_URI=${{ secrets.SPRING_DATA_MONGODB_URI }}
+            SERVER_PORT=${{ secrets.SERVER_PORT || 8080 }}
+            JAVA_OPTS=${{ secrets.JAVA_OPTS }}
+            EOF
+            # Write a minimal compose file if not present
+            if [ ! -f docker-compose.yml ]; then
+              cat > docker-compose.yml << YML
+            version: '3.8'
+            services:
+              app:
+                image: ${IMAGE}
+                ports:
+                  - "
+            ${SERVER_PORT:-8080}:8080"
+                env_file: .env
+                restart: unless-stopped
+            YML
+            fi
+            docker compose down || true
+            docker compose up -d
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,50 @@
+name: Docker Publish (GHCR)
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/review-tracker
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Multi-stage build for Review Tracker (UI + Backend)
+
+# 1) Build UI with Node
+FROM node:20-alpine AS ui-build
+WORKDIR /app
+COPY review-tracker-ui ./review-tracker-ui
+WORKDIR /app/review-tracker-ui
+# Install and build (needs devDependencies)
+RUN npm ci && npm run build
+
+# 2) Build backend JAR with Maven, inject built UI
+FROM maven:3.9-eclipse-temurin-21 AS backend-build
+WORKDIR /workspace
+# Copy only backend sources first (for better layer caching)
+COPY review-tracker-backend ./review-tracker-backend
+# Replace static resources with UI dist
+RUN rm -rf review-tracker-backend/src/main/resources/static && \
+    mkdir -p review-tracker-backend/src/main/resources/static
+COPY --from=ui-build /app/review-tracker-ui/dist/ review-tracker-backend/src/main/resources/static/
+# Build the Spring Boot JAR
+RUN mvn -f review-tracker-backend/pom.xml -DskipTests package
+
+# 3) Runtime image
+FROM eclipse-temurin:21-jre
+ENV JAVA_OPTS=""
+WORKDIR /app
+COPY --from=backend-build /workspace/review-tracker-backend/target/review-tracker-backend-0.0.1-SNAPSHOT.jar /app/app.jar
+EXPOSE 8080
+# Expect MongoDB Atlas URI via SPRING_DATA_MONGODB_URI, and optional SERVER_PORT
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN rm -rf review-tracker-backend/src/main/resources/static && \
     mkdir -p review-tracker-backend/src/main/resources/static
 COPY --from=ui-build /app/review-tracker-ui/dist/ review-tracker-backend/src/main/resources/static/
 # Build the Spring Boot JAR
-RUN mvn -f review-tracker-backend/pom.xml -DskipTests package
+# Skip compiling and running tests for container builds
+RUN mvn -f review-tracker-backend/pom.xml -Dmaven.test.skip=true package
 
 # 3) Runtime image
 FROM eclipse-temurin:21-jre
@@ -28,4 +29,3 @@ COPY --from=backend-build /workspace/review-tracker-backend/target/review-tracke
 EXPOSE 8080
 # Expect MongoDB Atlas URI via SPRING_DATA_MONGODB_URI, and optional SERVER_PORT
 ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar"]
-

--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ A full‑stack app to track product review and refund workflows. It provides a R
   - Create a database user (readWrite on your DB), allow your IP or environment in Atlas Network Access.
   - Connection string format: `mongodb+srv://user:pass@cluster.example.mongodb.net/review-tracker?retryWrites=true&w=majority&appName=ReviewTracker`
 
+## GitHub Actions (CI/CD)
+
+This repo includes basic GitHub Actions workflows under `.github/workflows/`:
+
+- `ci.yml`: builds the UI and packages the backend on pushes/PRs to `main`. Uploads the JAR as an artifact.
+- `docker-publish.yml`: builds and pushes a Docker image to GitHub Container Registry (GHCR) as `ghcr.io/<owner>/review-tracker` on push to `main` and tags.
+- `deploy-ssh.yml`: manual (workflow_dispatch) deployment to a remote host via SSH. It pulls the GHCR image and runs it with Docker Compose.
+
+Setup steps:
+
+1) Enable GHCR permissions for the repo
+   - Nothing to set manually; the workflows use the built-in `GITHUB_TOKEN` with `packages: write` permission.
+
+2) (Optional) Remote deploy via SSH
+   - Add repository secrets: `SSH_HOST`, `SSH_USER`, `SSH_KEY` (private key), `SPRING_DATA_MONGODB_URI`, `SERVER_PORT` (e.g., 8080), and optionally `JAVA_OPTS`.
+   - Run the `Deploy via SSH` workflow from the Actions tab with `image_tag` set to `latest` or a specific SHA tag.
+
+3) Publish container to GHCR
+   - On merge to `main`, `docker-publish.yml` will push tags `latest`, `sha-<short>` etc.
+   - Pull locally: `docker pull ghcr.io/<owner>/review-tracker:latest`
+
+
 ## Feature Overview
 
 - Reviews: create, view, update, delete; search and pagination.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ A full‑stack app to track product review and refund workflows. It provides a R
 - Tests:
   - `mvn -f review-tracker-backend/pom.xml test` (uses embedded Mongo for tests)
 
+## Docker
+
+- Build and run with Docker (MongoDB Atlas):
+  - Copy `.env.example` to `.env` and set `SPRING_DATA_MONGODB_URI` to your Atlas connection string.
+  - `docker compose up --build` (or `docker-compose up --build`)
+  - App listens on `http://localhost:${SERVER_PORT:-8080}`
+- Standalone Docker build (no compose):
+  - `docker build -t review-tracker .`
+  - `docker run -p 8080:8080 -e SPRING_DATA_MONGODB_URI='<atlas-uri>' review-tracker`
+- Note on Atlas:
+  - Create a database user (readWrite on your DB), allow your IP or environment in Atlas Network Access.
+  - Connection string format: `mongodb+srv://user:pass@cluster.example.mongodb.net/review-tracker?retryWrites=true&w=majority&appName=ReviewTracker`
+
 ## Feature Overview
 
 - Reviews: create, view, update, delete; search and pagination.
@@ -84,4 +97,3 @@ A full‑stack app to track product review and refund workflows. It provides a R
 ---
 
 For questions or PR reviews, open an issue or mention maintainers in your PR.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+services:
+  review-tracker:
+    build: .
+    ports:
+      - "${SERVER_PORT:-8080}:8080"
+    environment:
+      # Set this to your MongoDB Atlas connection string in a .env file or CI/CD secret
+      - SPRING_DATA_MONGODB_URI=${SPRING_DATA_MONGODB_URI}
+      # Optional: override server.port inside the container
+      - SERVER_PORT=${SERVER_PORT:-8080}
+      # Optional: JVM flags (e.g., memory)
+      - JAVA_OPTS=${JAVA_OPTS:-}
+    restart: unless-stopped
+


### PR DESCRIPTION
Adds basic CI/CD using GitHub Actions.\n\nWorkflows:\n- ci.yml: Build UI and package backend; upload JAR artifact.\n- docker-publish.yml: Build and push Docker image to GHCR (ghcr.io/<owner>/review-tracker) on pushes to main and tags.\n- deploy-ssh.yml: Manual workflow to deploy to a remote host via SSH by pulling the GHCR image and starting it with Docker Compose.\n\nSetup:\n- Ensure repo can write to GHCR (default GITHUB_TOKEN works).\n- For deploy-ssh.yml, add secrets: SSH_HOST, SSH_USER, SSH_KEY, SPRING_DATA_MONGODB_URI, SERVER_PORT, (optional) JAVA_OPTS.\n\nThis pairs with Dockerfile and docker-compose.yml already in the repo.