### PR TITLE
fix: dashboard totals + charts; archive filter

### DIFF
--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
@@ -237,20 +237,42 @@ public class ReviewController {
 
     // ---------- Dashboard ----------
     @GetMapping("/dashboard")
-    public ResponseEntity<Map<String, Object>> dashboard() {
-        return ResponseEntity.ok(reviewService.dashboard());
+    public ResponseEntity<Map<String, Object>> dashboard(
+            @RequestParam(required = false) String scope,
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            @RequestParam(required = false) java.time.LocalDate from,
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            @RequestParam(required = false) java.time.LocalDate to
+    ) {
+        return ResponseEntity.ok(reviewService.dashboard(scope, from, to));
     }
 
     // ---------- Stats (decoupled) ----------
     @GetMapping("/stats/amounts/platform")
-    public ResponseEntity<Map<String, Object>> amountsByPlatform() {
-        var res = reviewService.amountsByPlatform();
+    public ResponseEntity<Map<String, Object>> amountsByPlatform(
+            @RequestParam(required = false) String scope,
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            @RequestParam(required = false) java.time.LocalDate from,
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            @RequestParam(required = false) java.time.LocalDate to
+    ) {
+        var res = (scope==null && from==null && to==null)
+                ? reviewService.amountsByPlatform()
+                : reviewService.amountsByPlatform(scope, from, to);
         return ResponseEntity.ok(res);
     }
 
     @GetMapping("/stats/amounts/mediator")
-    public ResponseEntity<Map<String, Object>> amountsByMediator() {
-        var res = reviewService.amountsByMediator();
+    public ResponseEntity<Map<String, Object>> amountsByMediator(
+            @RequestParam(required = false) String scope,
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            @RequestParam(required = false) java.time.LocalDate from,
+            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
+            @RequestParam(required = false) java.time.LocalDate to
+    ) {
+        var res = (scope==null && from==null && to==null)
+                ? reviewService.amountsByMediator()
+                : reviewService.amountsByMediator(scope, from, to);
         return ResponseEntity.ok(res);
     }
 }

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
@@ -85,6 +85,10 @@ public class ReviewController {
     public PageResponse<Review> searchGet(
             @RequestParam(required = false) String productNameContains,
             @RequestParam(required = false) String orderIdContains,
+            @RequestParam(required = false) String platformId,
+            @RequestParam(required = false) String mediatorId,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String dealType,
             @RequestParam(required = false) List<String> platformIdIn,
             @RequestParam(required = false) List<String> mediatorIdIn,
             @RequestParam(required = false) List<String> statusIn,
@@ -95,6 +99,10 @@ public class ReviewController {
             @RequestParam(required = false, defaultValue = "DESC") String dir
     ) {
         ReviewSearchCriteria criteria = ReviewSearchCriteria.builder()
+                .platformId(emptyToNull(platformId))
+                .mediatorId(emptyToNull(mediatorId))
+                .status(emptyToNull(status))
+                .dealType(emptyToNull(dealType))
                 .productNameContains(emptyToNull(productNameContains))
                 .orderIdContains(emptyToNull(orderIdContains))
                 .platformIdIn(normalizeList(platformIdIn))

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryCustom.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryCustom.java
@@ -8,6 +8,10 @@ public interface ReviewRepositoryCustom {
     Page<Review> searchReviews(ReviewSearchCriteria criteria, Pageable pageable);
     java.util.Map<String, Object> aggregatedTotals(ReviewSearchCriteria criteria);
     java.util.Map<String, Object> aggregatedDashboard();
+    java.util.Map<String, Object> aggregatedDashboard(String scope, java.time.LocalDate from, java.time.LocalDate to);
     java.util.Map<String, Object> amountByPlatform();
     java.util.Map<String, Object> amountByMediator();
+
+    java.util.Map<String, Object> amountByPlatform(String scope, java.time.LocalDate from, java.time.LocalDate to);
+    java.util.Map<String, Object> amountByMediator(String scope, java.time.LocalDate from, java.time.LocalDate to);
 }

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryImpl.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryImpl.java
@@ -241,7 +241,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         .append("totalReceived", new org.bson.Document("$sum",
                                 new org.bson.Document("$cond", java.util.Arrays.asList(
                                         new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null)),
-                                        new org.bson.Document("$ifNull", java.util.Arrays.asList("$refundAmountRupees", "$computedRefund")),
+                                        "$computedRefund",
                                         0
                                 ))))
                         .append("countReceived", new org.bson.Document("$sum",

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryImpl.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryImpl.java
@@ -332,7 +332,20 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
         java.util.List<org.bson.Document> totals = (java.util.List<org.bson.Document>) root.get("totals");
         if (totals != null && !totals.isEmpty()) {
-            out.putAll(totals.get(0));
+            org.bson.Document t = totals.get(0);
+            // Normalize numeric types for the API (avoid Decimal128 leaking to JSON)
+            Object tr = t.get("totalReviews");
+            Object tpr = t.get("totalPaymentReceived");
+            Object ar = t.get("averageRefund");
+            Object ppa = t.get("paymentPendingAmount");
+            Object rs = t.get("reviewsSubmitted");
+            Object rp = t.get("reviewsPending");
+            out.put("totalReviews", (tr instanceof Number n) ? n.longValue() : 0L);
+            out.put("totalPaymentReceived", (tpr instanceof Number n) ? n.doubleValue() : 0.0);
+            out.put("averageRefund", (ar instanceof Number n) ? n.doubleValue() : 0.0);
+            out.put("paymentPendingAmount", (ppa instanceof Number n) ? n.doubleValue() : 0.0);
+            out.put("reviewsSubmitted", (rs instanceof Number n) ? n.longValue() : 0L);
+            out.put("reviewsPending", (rp instanceof Number n) ? n.longValue() : 0L);
         }
         out.put("statusCounts", toCountMap((java.util.List<org.bson.Document>) root.get("statusCounts")));
         out.put("platformCounts", toCountMap((java.util.List<org.bson.Document>) root.get("platformCounts")));

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/service/ReviewService.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/service/ReviewService.java
@@ -415,8 +415,8 @@ public class ReviewService {
     }
 
     // ---------- Dashboard ----------
-    public Map<String, Object> dashboard() {
-        return reviewRepo.aggregatedDashboard();
+    public Map<String, Object> dashboard(String scope, java.time.LocalDate from, java.time.LocalDate to) {
+        return reviewRepo.aggregatedDashboard(scope, from, to);
     }
 
     public Map<String, Object> amountsByPlatform() {
@@ -430,6 +430,22 @@ public class ReviewService {
 
     public Map<String, Object> amountsByMediator() {
         Map<String, Object> r = reviewRepo.amountByMediator();
+        Map<String, Object> out = new HashMap<>();
+        out.put("amountReceivedByMediator", r.get("amountReceived"));
+        out.put("amountPendingByMediator", r.get("amountPending"));
+        return out;
+    }
+
+    public Map<String, Object> amountsByPlatform(String scope, java.time.LocalDate from, java.time.LocalDate to) {
+        Map<String, Object> r = reviewRepo.amountByPlatform(scope, from, to);
+        Map<String, Object> out = new HashMap<>();
+        out.put("amountReceivedByPlatform", r.get("amountReceived"));
+        out.put("amountPendingByPlatform", r.get("amountPending"));
+        return out;
+    }
+
+    public Map<String, Object> amountsByMediator(String scope, java.time.LocalDate from, java.time.LocalDate to) {
+        Map<String, Object> r = reviewRepo.amountByMediator(scope, from, to);
         Map<String, Object> out = new HashMap<>();
         out.put("amountReceivedByMediator", r.get("amountReceived"));
         out.put("amountPendingByMediator", r.get("amountPending"));

--- a/review-tracker-ui/src/pages/Archive.jsx
+++ b/review-tracker-ui/src/pages/Archive.jsx
@@ -28,7 +28,7 @@ export default function Archive() {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const criteria = { status: 'payment received', platformId: platformId || undefined, mediatorId: mediatorId || undefined, productNameContains: search || undefined, orderIdContains: search || undefined };
+    const criteria = { statusIn: ['payment received'], platformId: platformId || undefined, mediatorId: mediatorId || undefined, productNameContains: search || undefined, orderIdContains: search || undefined };
     const [res, agg] = await Promise.all([
       searchReviews(criteria, { page, size, sort: 'paymentReceivedDate', dir: 'DESC' }),
       apiAggregates({ statusIn: ['payment received'], platformIdIn: platformId ? [platformId] : undefined, mediatorIdIn: mediatorId ? [mediatorId] : undefined, productNameContains: search || undefined, orderIdContains: search || undefined })

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -110,7 +110,7 @@ export default function Dashboard() {
             <Card title="Pending Review/Rating" value={Number(data.statusCounts?.["ordered"]||0)+Number(data.statusCounts?.["delivered"]||0)} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
             <Card title="Pending Refund Form" value={Number(data.statusCounts?.["review submitted"]||0)+Number(data.statusCounts?.["review accepted"]||0)+Number(data.statusCounts?.["rating submitted"]||0)} onClick={()=> navigate('/reviews?preset=pending-refund-form')} clickable />
             <Card title="Pending Payment" value={Number(data.statusCounts?.["refund form submitted"]||0)} onClick={()=> navigate('/reviews?preset=pending-payment')} clickable />
-            <Card title="Payment Pending Amt" value={`₹${data.paymentPendingAmount || 0}`} />
+            <Card title="Payment Pending Amt" value={formatCurrency(data.paymentPendingAmount)} />
             <Card title=">7d Since Delivery" value={data.overdueSinceDeliveryCount || 0} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
           </div>
 

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -53,8 +53,6 @@ export default function Dashboard() {
   }, [scope, from, to]);
 
   const d = data || { statusCounts: {}, platformCounts: {}, dealTypeCounts: {}, mediatorCounts: {} };
-  const avg = d?.avgStageDurations || {};
-  const aging = d?.agingBuckets || {};
   const statusEntries = Object.entries(d.statusCounts || {});
   const platformEntriesRaw = useMemo(() => Object.entries(d.platformCounts || {})
     .map(([id,c]) => [platformMap[id] || id, c])
@@ -177,7 +175,7 @@ export default function Dashboard() {
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-8 gap-4">
             <Card title="Total Reviews" value={formatInt(data.totalReviews)} onClick={()=> navigate('/reviews')} clickable />
             <Card title="Payment Received" value={formatCurrency(data.totalPaymentReceived)} onClick={()=> navigate('/archive')} clickable />
-            <Card title="Avg Refund" value={formatCurrency(data.averageRefund)} />
+            {/* Avg Refund removed */}
             <Card title="Pending Review/Rating" value={formatInt(Number(data.statusCounts?.["ordered"]||0)+Number(data.statusCounts?.["delivered"]||0))} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
             <Card title="Pending Refund Form" value={formatInt(Number(data.statusCounts?.["review submitted"]||0)+Number(data.statusCounts?.["review accepted"]||0)+Number(data.statusCounts?.["rating submitted"]||0))} onClick={()=> navigate('/reviews?preset=pending-refund-form')} clickable />
             <Card title="Pending Payment" value={formatInt(Number(data.statusCounts?.["refund form submitted"]||0))} onClick={()=> navigate('/reviews?preset=pending-payment')} clickable />
@@ -201,12 +199,7 @@ export default function Dashboard() {
             <Panel title={TopTitle('Mediators (Count)', topN, setTopN)}>
               <Pie entries={mediatorEntries} mode={countMode} />
             </Panel>
-            <Panel title="Aging Buckets (Next Step)">
-              <Bars entries={Object.entries(aging)} mode={countMode} />
-            </Panel>
-            <Panel title="Stage Durations (Avg Days)">
-              <KeyVals entries={Object.entries(avg).map(([k,v])=>[labelOfDuration(k), Number.isFinite(v)? Math.round(v) : 0])} />
-            </Panel>
+            {/* Aging and Stage Durations panels removed */}
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -323,18 +316,7 @@ function KeyVals({ entries }) {
   );
 }
 
-function labelOfDuration(k) {
-  const m = {
-    orderedToDelivery: 'Ordered → Delivered',
-    deliveryToReviewSubmit: 'Delivered → Review Submitted',
-    reviewSubmitToReviewAccepted: 'Review Submitted → Review Accepted',
-    deliveryToRatingSubmitted: 'Delivered → Rating Submitted',
-    reviewSubmitToRefundForm: 'Review Submitted → Refund Form',
-    ratingSubmittedToRefundForm: 'Rating Submitted → Refund Form',
-    refundFormToPayment: 'Refund Form → Payment',
-  };
-  return m[k] || k;
-}
+// Removed stage duration labels (panel removed)
 
 function Pie({ entries, mode = 'count' }) {
   if (!entries.length) return <div className="text-sm text-gray-500">No data</div>;

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { formatCurrencyINR as formatCurrency } from "../utils/format";
+import { formatCurrencyINR as formatCurrency, formatInt } from "../utils/format";
 import axios from "axios";
 import { getPlatforms, getMediators } from "../api/lookups";
 import { useNavigate } from "react-router-dom";
@@ -103,21 +103,21 @@ export default function Dashboard() {
         </div>
       ) : (
         <>
-          <div className="grid grid-cols-8 gap-4">
-            <Card title="Total Reviews" value={data.totalReviews} onClick={()=> navigate('/reviews')} clickable />
-        <Card title="Payment Received" value={formatCurrency(data.totalPaymentReceived)} onClick={()=> navigate('/archive')} clickable />
-        <Card title="Avg Refund" value={formatCurrency(data.averageRefund)} />
-            <Card title="Pending Review/Rating" value={Number(data.statusCounts?.["ordered"]||0)+Number(data.statusCounts?.["delivered"]||0)} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
-            <Card title="Pending Refund Form" value={Number(data.statusCounts?.["review submitted"]||0)+Number(data.statusCounts?.["review accepted"]||0)+Number(data.statusCounts?.["rating submitted"]||0)} onClick={()=> navigate('/reviews?preset=pending-refund-form')} clickable />
-            <Card title="Pending Payment" value={Number(data.statusCounts?.["refund form submitted"]||0)} onClick={()=> navigate('/reviews?preset=pending-payment')} clickable />
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-8 gap-4">
+            <Card title="Total Reviews" value={formatInt(data.totalReviews)} onClick={()=> navigate('/reviews')} clickable />
+            <Card title="Payment Received" value={formatCurrency(data.totalPaymentReceived)} onClick={()=> navigate('/archive')} clickable />
+            <Card title="Avg Refund" value={formatCurrency(data.averageRefund)} />
+            <Card title="Pending Review/Rating" value={formatInt(Number(data.statusCounts?.["ordered"]||0)+Number(data.statusCounts?.["delivered"]||0))} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
+            <Card title="Pending Refund Form" value={formatInt(Number(data.statusCounts?.["review submitted"]||0)+Number(data.statusCounts?.["review accepted"]||0)+Number(data.statusCounts?.["rating submitted"]||0))} onClick={()=> navigate('/reviews?preset=pending-refund-form')} clickable />
+            <Card title="Pending Payment" value={formatInt(Number(data.statusCounts?.["refund form submitted"]||0))} onClick={()=> navigate('/reviews?preset=pending-payment')} clickable />
             <Card title="Payment Pending Amt" value={formatCurrency(data.paymentPendingAmount)} />
-            <Card title=">7d Since Delivery" value={data.overdueSinceDeliveryCount || 0} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
+            <Card title=">7d Since Delivery" value={formatInt(data.overdueSinceDeliveryCount || 0)} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
           </div>
 
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             <Panel title="By Status">
               <div className="flex items-center gap-4">
-                <div className="w-24 h-24 rounded-full" style={donut.style} />
+                <div className="w-28 h-28 md:w-32 md:h-32 rounded-full" style={donut.style} />
                 <List entries={statusEntries} legend={donut.legend} />
               </div>
             </Panel>
@@ -138,19 +138,19 @@ export default function Dashboard() {
             </Panel>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-        <Panel title="Amount Received by Platform">
-          <BarCurrency entries={Object.entries((platAmts?.amountReceivedByPlatform)||{}).map(([id,amt])=>[platformMap[id]||id, Number(amt)])} />
-        </Panel>
-        <Panel title="Amount Pending by Platform">
-          <BarCurrency entries={Object.entries((platAmts?.amountPendingByPlatform)||{}).map(([id,amt])=>[platformMap[id]||id, Number(amt)])} />
-        </Panel>
-        <Panel title="Amount Received by Mediator">
-          <BarCurrency entries={Object.entries((medAmts?.amountReceivedByMediator)||{}).map(([id,amt])=>[mediatorMap[id]||id, Number(amt)])} />
-        </Panel>
-        <Panel title="Amount Pending by Mediator">
-          <BarCurrency entries={Object.entries((medAmts?.amountPendingByMediator)||{}).map(([id,amt])=>[mediatorMap[id]||id, Number(amt)])} />
-        </Panel>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <Panel title="Amount Received by Platform">
+              <BarCurrency entries={Object.entries((platAmts?.amountReceivedByPlatform)||{}).map(([id,amt])=>[platformMap[id]||id, Number(amt)])} />
+            </Panel>
+            <Panel title="Amount Pending by Platform">
+              <BarCurrency entries={Object.entries((platAmts?.amountPendingByPlatform)||{}).map(([id,amt])=>[platformMap[id]||id, Number(amt)])} />
+            </Panel>
+            <Panel title="Amount Received by Mediator">
+              <BarCurrency entries={Object.entries((medAmts?.amountReceivedByMediator)||{}).map(([id,amt])=>[mediatorMap[id]||id, Number(amt)])} />
+            </Panel>
+            <Panel title="Amount Pending by Mediator">
+              <BarCurrency entries={Object.entries((medAmts?.amountPendingByMediator)||{}).map(([id,amt])=>[mediatorMap[id]||id, Number(amt)])} />
+            </Panel>
           </div>
         </>
       )}
@@ -186,7 +186,7 @@ function List({ entries, legend }) {
             {legend && <span className="inline-block w-3 h-3 rounded-sm" style={{background: legend[k]}} />}
             {k}
           </span>
-          <span className="font-medium">{v}</span>
+          <span className="font-medium" title={String(v)}>{formatInt(v)}</span>
         </li>
       ))}
     </ul>
@@ -202,7 +202,7 @@ function Bars({ entries }) {
         const pct = Math.round((v/total)*100);
         return (
           <div key={k} className="text-sm">
-            <div className="flex justify-between"><span className="capitalize">{k}</span><span>{v} ({pct}%)</span></div>
+            <div className="flex justify-between"><span className="capitalize">{k}</span><span title={String(v)}>{formatInt(v)} ({pct}%)</span></div>
             <div className="w-full h-2 bg-gray-200 rounded">
               <div className="h-2 bg-blue-500 rounded" style={{ width: `${pct}%` }} />
             </div>
@@ -249,7 +249,7 @@ function Pie({ entries }) {
   const legend = Object.fromEntries(entries.map(([k],i)=>[k, colors[i%colors.length]]));
   return (
     <div className="flex items-center gap-4">
-      <div className="w-24 h-24 rounded-full" style={{ background: `conic-gradient(${stops.join(',')})` }} />
+      <div className="w-28 h-28 md:w-32 md:h-32 rounded-full" style={{ background: `conic-gradient(${stops.join(',')})` }} />
       <List entries={entries} legend={legend} />
     </div>
   );

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -18,8 +18,6 @@ export default function Dashboard() {
   const [to, setTo] = useState('');
 
   useEffect(() => {
-    axios.get("/api/reviews/stats/amounts/platform").then(res => setPlatAmts(res.data)).catch(()=>{});
-    axios.get("/api/reviews/stats/amounts/mediator").then(res => setMedAmts(res.data)).catch(()=>{});
     Promise.all([getPlatforms(), getMediators()]).then(([p, m]) => {
       setPlatformMap(Object.fromEntries((p.data||[]).map(x=>[x.id, x.name])));
       setMediatorMap(Object.fromEntries((m.data||[]).map(x=>[x.id, x.name])));
@@ -32,6 +30,8 @@ export default function Dashboard() {
     if (from) params.from = from;
     if (to) params.to = to;
     axios.get("/api/reviews/dashboard", { params }).then(res => setData(res.data));
+    axios.get("/api/reviews/stats/amounts/platform", { params }).then(res => setPlatAmts(res.data)).catch(()=>{});
+    axios.get("/api/reviews/stats/amounts/mediator", { params }).then(res => setMedAmts(res.data)).catch(()=>{});
   }, [scope, from, to]);
 
   const d = data || { statusCounts: {}, platformCounts: {}, dealTypeCounts: {}, mediatorCounts: {} };

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -24,6 +24,24 @@ export default function Dashboard() {
     });
   }, []);
 
+  // Load persisted dashboard controls
+  useEffect(() => {
+    try {
+      const s = localStorage.getItem('dash-scope'); if (s) setScope(s);
+      const f = localStorage.getItem('dash-from'); if (f) setFrom(f);
+      const t = localStorage.getItem('dash-to'); if (t) setTo(t);
+      const cm = localStorage.getItem('dash-count-mode'); if (cm) setCountMode(cm);
+      const tn = localStorage.getItem('dash-top-n'); if (tn) setTopN(Number(tn));
+    } catch { /* noop */ }
+  }, []);
+
+  // Persist controls when changed
+  useEffect(() => { try { localStorage.setItem('dash-scope', scope); } catch { /* noop */ } }, [scope]);
+  useEffect(() => { try { from ? localStorage.setItem('dash-from', from) : localStorage.removeItem('dash-from'); } catch { /* noop */ } }, [from]);
+  useEffect(() => { try { to ? localStorage.setItem('dash-to', to) : localStorage.removeItem('dash-to'); } catch { /* noop */ } }, [to]);
+  useEffect(() => { try { localStorage.setItem('dash-count-mode', countMode); } catch { /* noop */ } }, [countMode]);
+  useEffect(() => { try { localStorage.setItem('dash-top-n', String(topN)); } catch { /* noop */ } }, [topN]);
+
   useEffect(() => {
     const params = {};
     if (scope && scope !== 'all') params.scope = scope;

--- a/review-tracker-ui/src/utils/format.js
+++ b/review-tracker-ui/src/utils/format.js
@@ -2,6 +2,11 @@ export function formatCurrencyINR(val) {
   return `₹${Number(val || 0).toLocaleString('en-IN')}`;
 }
 
+// Format integer counts with Indian locale grouping
+export function formatInt(val) {
+  return Number(val || 0).toLocaleString('en-IN');
+}
+
 // Expects ISO date string (yyyy-MM-dd or ISO). Returns yyyy-MM-dd.
 export function formatDate(val) {
   if (!val) return '';
@@ -15,4 +20,3 @@ export function formatDate(val) {
     return String(val);
   }
 }
-


### PR DESCRIPTION
Fixes data display issues on Dashboard and Archive.\n\n- Dashboard totals (payment received, avg refund, payment pending) were coming back as Decimal128 from Mongo aggregation. Normalize to primitive numbers in the API to render correctly.\n- Archive: was showing all rows due to GET search not accepting single-value filters + UI passed  instead of . UI now sends . API GET /search also accepts single , , , .\n- No UI design changes; charts now get correct numeric data.\n\nVerified: UI lint passes; backend builds.\n