### PR TITLE
Dashboard MVP: redesign, cleanup, overdue metric, and new UI

### DIFF
--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/api/controller/ReviewController.java
@@ -235,44 +235,12 @@ public class ReviewController {
         return ResponseEntity.ok(reviewService.importCsv(file));
     }
 
-    // ---------- Dashboard ----------
-    @GetMapping("/dashboard")
-    public ResponseEntity<Map<String, Object>> dashboard(
-            @RequestParam(required = false) String scope,
-            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
-            @RequestParam(required = false) java.time.LocalDate from,
-            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
-            @RequestParam(required = false) java.time.LocalDate to
-    ) {
-        return ResponseEntity.ok(reviewService.dashboard(scope, from, to));
+    // ---------- Metrics (MVP) ----------
+    @GetMapping("/metrics/overdue-count")
+    public ResponseEntity<java.util.Map<String, Long>> overdueCount() {
+        long c = reviewService.overdueCount();
+        return ResponseEntity.ok(java.util.Map.of("overdue", c));
     }
 
-    // ---------- Stats (decoupled) ----------
-    @GetMapping("/stats/amounts/platform")
-    public ResponseEntity<Map<String, Object>> amountsByPlatform(
-            @RequestParam(required = false) String scope,
-            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
-            @RequestParam(required = false) java.time.LocalDate from,
-            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
-            @RequestParam(required = false) java.time.LocalDate to
-    ) {
-        var res = (scope==null && from==null && to==null)
-                ? reviewService.amountsByPlatform()
-                : reviewService.amountsByPlatform(scope, from, to);
-        return ResponseEntity.ok(res);
-    }
-
-    @GetMapping("/stats/amounts/mediator")
-    public ResponseEntity<Map<String, Object>> amountsByMediator(
-            @RequestParam(required = false) String scope,
-            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
-            @RequestParam(required = false) java.time.LocalDate from,
-            @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
-            @RequestParam(required = false) java.time.LocalDate to
-    ) {
-        var res = (scope==null && from==null && to==null)
-                ? reviewService.amountsByMediator()
-                : reviewService.amountsByMediator(scope, from, to);
-        return ResponseEntity.ok(res);
-    }
+    // Dashboard and dashboard-related stats endpoints removed for redesign
 }

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepository.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface ReviewRepository extends ReviewRepositoryCustom, MongoRepository<Review, String> {
     Optional<Review> findByOrderId(String orderId);
     boolean existsByOrderId(String orderId);
+    long countByDeliveryDateBeforeAndPaymentReceivedDateIsNull(java.time.LocalDate date);
 }

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryCustom.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryCustom.java
@@ -7,11 +7,4 @@ import org.springframework.data.domain.Pageable;
 public interface ReviewRepositoryCustom {
     Page<Review> searchReviews(ReviewSearchCriteria criteria, Pageable pageable);
     java.util.Map<String, Object> aggregatedTotals(ReviewSearchCriteria criteria);
-    java.util.Map<String, Object> aggregatedDashboard();
-    java.util.Map<String, Object> aggregatedDashboard(String scope, java.time.LocalDate from, java.time.LocalDate to);
-    java.util.Map<String, Object> amountByPlatform();
-    java.util.Map<String, Object> amountByMediator();
-
-    java.util.Map<String, Object> amountByPlatform(String scope, java.time.LocalDate from, java.time.LocalDate to);
-    java.util.Map<String, Object> amountByMediator(String scope, java.time.LocalDate from, java.time.LocalDate to);
 }

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryImpl.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/repository/ReviewRepositoryImpl.java
@@ -6,19 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Arrays;
-import java.util.regex.Pattern;
+import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -42,6 +37,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         if (criteria.getMediatorId() != null) filters.add(Criteria.where("mediatorId").is(criteria.getMediatorId()));
         if (criteria.getMediatorIdIn() != null && !criteria.getMediatorIdIn().isEmpty())
             filters.add(Criteria.where("mediatorId").in(criteria.getMediatorIdIn()));
+
         if (criteria.getDealType() != null) filters.add(Criteria.where("dealType").is(criteria.getDealType()));
         if (criteria.getDealTypeIn() != null && !criteria.getDealTypeIn().isEmpty())
             filters.add(Criteria.where("dealType").in(criteria.getDealTypeIn()));
@@ -70,23 +66,26 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
     }
 
     @Override
-    public java.util.Map<String, Object> aggregatedTotals(ReviewSearchCriteria criteria) {
-        List<AggregationOperation> ops = new ArrayList<>();
-        // match
+    public Map<String, Object> aggregatedTotals(ReviewSearchCriteria criteria) {
+        Query query = new Query();
         List<Criteria> filters = new ArrayList<>();
+
         if (criteria.getPlatformId() != null) filters.add(Criteria.where("platformId").is(criteria.getPlatformId()));
         if (criteria.getPlatformIdIn() != null && !criteria.getPlatformIdIn().isEmpty())
             filters.add(Criteria.where("platformId").in(criteria.getPlatformIdIn()));
+
         if (criteria.getStatus() != null) filters.add(Criteria.where("status").is(criteria.getStatus()));
         if (criteria.getStatusIn() != null && !criteria.getStatusIn().isEmpty())
             filters.add(Criteria.where("status").in(criteria.getStatusIn()));
+
         if (criteria.getMediatorId() != null) filters.add(Criteria.where("mediatorId").is(criteria.getMediatorId()));
         if (criteria.getMediatorIdIn() != null && !criteria.getMediatorIdIn().isEmpty())
             filters.add(Criteria.where("mediatorId").in(criteria.getMediatorIdIn()));
+
         if (criteria.getDealType() != null) filters.add(Criteria.where("dealType").is(criteria.getDealType()));
         if (criteria.getDealTypeIn() != null && !criteria.getDealTypeIn().isEmpty())
             filters.add(Criteria.where("dealType").in(criteria.getDealTypeIn()));
-        // Mirror quick search OR logic for aggregates
+
         if (criteria.getProductNameContains() != null && criteria.getOrderIdContains() != null) {
             filters.add(new Criteria().orOperator(
                     Criteria.where("productName").regex(criteria.getProductNameContains(), "i"),
@@ -97,465 +96,33 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         } else if (criteria.getOrderIdContains() != null) {
             filters.add(Criteria.where("orderId").regex(criteria.getOrderIdContains(), "i"));
         }
+
         if (!filters.isEmpty()) {
-            ops.add(context -> new org.bson.Document("$match", new org.bson.Document(new Criteria().andOperator(filters.toArray(new Criteria[0])).getCriteriaObject())));
+            query.addCriteria(new Criteria().andOperator(filters.toArray(new Criteria[0])));
         }
 
-        // Add computedRefund using sanitized numeric fields (remove commas/spaces)
-        org.bson.Document sanitizeAmount = org.bson.Document.parse("{ \"$toDouble\": { \"$replaceAll\": { \"input\": { \"$replaceAll\": { \"input\": { \"$trim\": { \"input\": { \"$toString\": \"$amountRupees\" } } }, \"find\": \",\", \"replacement\": \"\" } }, \"find\": \" \", \"replacement\": \"\" } } }");
-        org.bson.Document sanitizeLess = org.bson.Document.parse("{ \"$toDouble\": { \"$replaceAll\": { \"input\": { \"$replaceAll\": { \"input\": { \"$trim\": { \"input\": { \"$toString\": \"$lessRupees\" } } }, \"find\": \",\", \"replacement\": \"\" } }, \"find\": \" \", \"replacement\": \"\" } } }");
-        org.bson.Document sanitizeRefund = org.bson.Document.parse("{ \"$toDouble\": { \"$replaceAll\": { \"input\": { \"$replaceAll\": { \"input\": { \"$trim\": { \"input\": { \"$toString\": \"$refundAmountRupees\" } } }, \"find\": \",\", \"replacement\": \"\" } }, \"find\": \" \", \"replacement\": \"\" } } }");
+        List<Review> list = mongoTemplate.find(query, Review.class);
 
-        ops.add(context -> new org.bson.Document("$addFields",
-                new org.bson.Document("amountNum", sanitizeAmount)
-                        .append("lessNum", sanitizeLess)
-                        .append("refundNum", sanitizeRefund)));
+        long count = list.size();
+        BigDecimal totalAmount = BigDecimal.ZERO;
+        BigDecimal totalRefund = BigDecimal.ZERO;
 
-        org.bson.Document computedRefundExpr = new org.bson.Document("$ifNull",
-                java.util.Arrays.asList(
-                        sanitizeRefund,
-                        new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$amountNum", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$lessNum", null))
-                                )),
-                                new org.bson.Document("$subtract", java.util.Arrays.asList("$amountNum", "$lessNum")),
-                                0
-                        ))
-                )
-        );
-
-        ops.add(context -> new org.bson.Document("$addFields", new org.bson.Document("computedRefund", computedRefundExpr)));
-
-        // group totals
-        org.bson.Document groupFields = new org.bson.Document("_id", null)
-                .append("count", new org.bson.Document("$sum", 1))
-                .append("totalAmount", new org.bson.Document("$sum", "$amountNum"))
-                .append("totalRefund", new org.bson.Document("$sum", "$computedRefund"));
-        ops.add(context -> new org.bson.Document("$group", groupFields));
-
-        Aggregation agg = Aggregation.newAggregation(ops);
-        org.bson.Document result = mongoTemplate.aggregate(agg, Review.class, org.bson.Document.class)
-                .getUniqueMappedResult();
-        java.util.Map<String, Object> out = new java.util.HashMap<>();
-        if (result != null) {
-            Object c = result.getOrDefault("count", 0);
-            Object ta = result.get("totalAmount");
-            Object tr = result.get("totalRefund");
-            out.put("count", (c instanceof Number n) ? n.longValue() : 0L);
-            out.put("totalAmount", (ta instanceof Number n) ? n.doubleValue() : 0.0);
-            out.put("totalRefund", (tr instanceof Number n) ? n.doubleValue() : 0.0);
-        } else {
-            out.put("count", 0L);
-            out.put("totalAmount", 0.0);
-            out.put("totalRefund", 0.0);
-        }
-        return out;
-    }
-
-    @Override
-    public java.util.Map<String, Object> aggregatedDashboard() {
-        return aggregatedDashboard(null, null, null);
-    }
-
-    @Override
-    public java.util.Map<String, Object> aggregatedDashboard(String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        List<AggregationOperation> ops = new ArrayList<>();
-
-        // computedRefund = refundAmountRupees ?? ((amountRupees && lessRupees) ? amountRupees-lessRupees : 0)
-        org.bson.Document amountAndLessPresent = new org.bson.Document("$and", java.util.Arrays.asList(
-                new org.bson.Document("$ne", java.util.Arrays.asList("$amountRupees", null)),
-                new org.bson.Document("$ne", java.util.Arrays.asList("$lessRupees", null))
-        ));
-        org.bson.Document fallbackSubtract = new org.bson.Document("$cond",
-                java.util.Arrays.asList(
-                        amountAndLessPresent,
-                        new org.bson.Document("$subtract", java.util.Arrays.asList("$amountRupees", "$lessRupees")),
-                        0
-                )
-        );
-        org.bson.Document computedRefundExpr = new org.bson.Document("$ifNull",
-                java.util.Arrays.asList("$refundAmountRupees", fallbackSubtract)
-        );
-        ops.add(context -> new org.bson.Document("$addFields", new org.bson.Document("computedRefund", computedRefundExpr)));
-
-        // Precompute 'completed' flag (flow finished) per dealType for pending/overdue logic
-        org.bson.Document completedExpr = new org.bson.Document("$switch",
-                new org.bson.Document("branches", java.util.Arrays.asList(
-                        new org.bson.Document("case", new org.bson.Document("$eq", java.util.Arrays.asList("$dealType", "REVIEW_PUBLISHED")))
-                                .append("then", new org.bson.Document("$and", java.util.Arrays.asList(
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$reviewSubmitDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$reviewAcceptedDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$refundFormSubmittedDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null))
-                                ))),
-                        new org.bson.Document("case", new org.bson.Document("$eq", java.util.Arrays.asList("$dealType", "RATING_ONLY")))
-                                .append("then", new org.bson.Document("$and", java.util.Arrays.asList(
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$ratingSubmittedDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$refundFormSubmittedDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null))
-                                ))),
-                        new org.bson.Document("case", new org.bson.Document("$eq", java.util.Arrays.asList("$dealType", "REVIEW_SUBMISSION")))
-                                .append("then", new org.bson.Document("$and", java.util.Arrays.asList(
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$reviewSubmitDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$refundFormSubmittedDate", null)),
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null))
-                                )))
-                )).append("default", false));
-        ops.add(context -> new org.bson.Document("$addFields", new org.bson.Document("completed", completedExpr)));
-
-        // Date anchors for aging buckets (JSON parse to avoid builder nesting)
-        org.bson.Document anchorExpr = org.bson.Document.parse("{\n" +
-                "  \"$switch\": {\n" +
-                "    \"branches\": [\n" +
-                "      { \"case\": { \"$eq\": [ \"$dealType\", \"REVIEW_PUBLISHED\" ] }, \"then\": { \"$cond\": [ { \"$eq\": [ \"$reviewSubmitDate\", null ] }, \"$deliveryDate\", { \"$cond\": [ { \"$eq\": [ \"$reviewAcceptedDate\", null ] }, \"$reviewSubmitDate\", { \"$cond\": [ { \"$eq\": [ \"$refundFormSubmittedDate\", null ] }, \"$reviewAcceptedDate\", { \"$cond\": [ { \"$eq\": [ \"$paymentReceivedDate\", null ] }, \"$refundFormSubmittedDate\", null ] } ] } ] } ] } },\n" +
-                "      { \"case\": { \"$eq\": [ \"$dealType\", \"RATING_ONLY\" ] }, \"then\": { \"$cond\": [ { \"$eq\": [ \"$ratingSubmittedDate\", null ] }, \"$deliveryDate\", { \"$cond\": [ { \"$eq\": [ \"$refundFormSubmittedDate\", null ] }, \"$ratingSubmittedDate\", { \"$cond\": [ { \"$eq\": [ \"$paymentReceivedDate\", null ] }, \"$refundFormSubmittedDate\", null ] } ] } ] } },\n" +
-                "      { \"case\": { \"$eq\": [ \"$dealType\", \"REVIEW_SUBMISSION\" ] }, \"then\": { \"$cond\": [ { \"$eq\": [ \"$reviewSubmitDate\", null ] }, \"$deliveryDate\", { \"$cond\": [ { \"$eq\": [ \"$refundFormSubmittedDate\", null ] }, \"$reviewSubmitDate\", { \"$cond\": [ { \"$eq\": [ \"$paymentReceivedDate\", null ] }, \"$refundFormSubmittedDate\", null ] } ] } ] } }\n" +
-                "    ],\n" +
-                "    \"default\": null\n" +
-                "  }\n" +
-                "}");
-        ops.add(context -> new org.bson.Document("$addFields", new org.bson.Document("anchorDate", anchorExpr)));
-
-        // build reference dates for overdue and aging buckets
-        java.util.Date now = new java.util.Date();
-        java.util.Calendar cal = java.util.Calendar.getInstance();
-        cal.setTime(now); cal.add(java.util.Calendar.DAY_OF_MONTH, -7); java.util.Date nowMinus7 = cal.getTime();
-        cal.setTime(now); cal.add(java.util.Calendar.DAY_OF_MONTH, -14); java.util.Date nowMinus14 = cal.getTime();
-        cal.setTime(now); cal.add(java.util.Calendar.DAY_OF_MONTH, -30); java.util.Date nowMinus30 = cal.getTime();
-
-        // Optional scope/date filters prior to facet
-        // Scope: 'received' => paymentReceivedDate != null; 'pending' => completed != true; else all
-        if ("received".equalsIgnoreCase(scope)) {
-            ops.add(context -> new org.bson.Document("$match", new org.bson.Document("paymentReceivedDate", new org.bson.Document("$ne", null))));
-        } else if ("pending".equalsIgnoreCase(scope)) {
-            ops.add(context -> new org.bson.Document("$match", new org.bson.Document("completed", new org.bson.Document("$ne", true))));
-        }
-
-        // Date window (apply before facet): for 'received' use paymentReceivedDate; otherwise use createdAt
-        if (from != null || to != null) {
-            java.util.Date fromD = null, toD = null;
-            if (from != null) fromD = java.util.Date.from(from.atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-            if (to != null) toD = java.util.Date.from(to.plusDays(1).atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-            String dateField = ("received".equalsIgnoreCase(scope)) ? "paymentReceivedDate" : "createdAt";
-            org.bson.Document range = new org.bson.Document();
-            if (fromD != null) range.append("$gte", fromD);
-            if (toD != null) range.append("$lt", toD);
-            ops.add(context -> new org.bson.Document("$match", new org.bson.Document(dateField, range)));
-        }
-
-        // facet
-        org.bson.Document facet = new org.bson.Document();
-
-        // totals
-        facet.append("totals", java.util.Arrays.asList(
-                new org.bson.Document("$group", new org.bson.Document("_id", null)
-                        .append("totalReviews", new org.bson.Document("$sum", 1))
-                        .append("totalReceived", new org.bson.Document("$sum",
-                                new org.bson.Document("$cond", java.util.Arrays.asList(
-                                        new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null)),
-                                        "$computedRefund",
-                                        0
-                                ))))
-                        .append("countReceived", new org.bson.Document("$sum",
-                                new org.bson.Document("$cond", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null)), 1, 0))))
-                        .append("pendingAmount", new org.bson.Document("$sum",
-                                new org.bson.Document("$cond", java.util.Arrays.asList(new org.bson.Document("$eq", java.util.Arrays.asList("$paymentReceivedDate", null)), "$computedRefund", 0))))
-                        .append("submittedCount", new org.bson.Document("$sum",
-                                new org.bson.Document("$cond", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$reviewSubmitDate", null)), 1, 0))))
-                ),
-                new org.bson.Document("$project", new org.bson.Document("_id", 0)
-                        .append("totalReviews", 1)
-                        .append("totalPaymentReceived", "$totalReceived")
-                        .append("averageRefund", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$gt", java.util.Arrays.asList("$countReceived", 0)),
-                                new org.bson.Document("$divide", java.util.Arrays.asList("$totalReceived", "$countReceived")),
-                                0
-                        )))
-                        .append("paymentPendingAmount", "$pendingAmount")
-                        .append("reviewsSubmitted", "$submittedCount")
-                        .append("reviewsPending", new org.bson.Document("$subtract", java.util.Arrays.asList("$totalReviews", "$submittedCount")))
-                )
-        ));
-
-        // generic group helper via inline docs
-        facet.append("statusCounts", java.util.List.of(
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$status", "unknown")))
-                        .append("c", new org.bson.Document("$sum", 1)))
-        ));
-        facet.append("platformCounts", java.util.List.of(
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$platformId", "unknown")))
-                        .append("c", new org.bson.Document("$sum", 1)))
-        ));
-        facet.append("dealTypeCounts", java.util.List.of(
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$dealType", "unknown")))
-                        .append("c", new org.bson.Document("$sum", 1)))
-        ));
-        facet.append("mediatorCounts", java.util.List.of(
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$mediatorId", "unknown")))
-                        .append("c", new org.bson.Document("$sum", 1)))
-        ));
-
-        facet.append("receivedByPlatform", java.util.List.of(
-                new org.bson.Document("$match", new org.bson.Document("paymentReceivedDate", new org.bson.Document("$ne", null))),
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$platformId", "unknown")))
-                        .append("amt", new org.bson.Document("$sum", "$computedRefund")))
-        ));
-        facet.append("pendingByPlatform", java.util.List.of(
-                new org.bson.Document("$match", new org.bson.Document("paymentReceivedDate", null)),
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$platformId", "unknown")))
-                        .append("amt", new org.bson.Document("$sum", "$computedRefund")))
-        ));
-        facet.append("receivedByMediator", java.util.List.of(
-                new org.bson.Document("$match", new org.bson.Document("paymentReceivedDate", new org.bson.Document("$ne", null))),
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$mediatorId", "unknown")))
-                        .append("amt", new org.bson.Document("$sum", "$computedRefund")))
-        ));
-        facet.append("pendingByMediator", java.util.List.of(
-                new org.bson.Document("$match", new org.bson.Document("paymentReceivedDate", null)),
-                new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$mediatorId", "unknown")))
-                        .append("amt", new org.bson.Document("$sum", "$computedRefund")))
-        ));
-
-        facet.append("overdue", java.util.List.of(
-                new org.bson.Document("$match", new org.bson.Document("deliveryDate", new org.bson.Document("$ne", null))),
-                new org.bson.Document("$match", new org.bson.Document("deliveryDate", new org.bson.Document("$lt", nowMinus7))),
-                new org.bson.Document("$match", new org.bson.Document("completed", false)),
-                new org.bson.Document("$count", "count")
-        ));
-
-        // aging removed per requirements
-
-        facet.append("avgDurations", java.util.Arrays.asList(
-                new org.bson.Document("$project", new org.bson.Document()
-                        .append("d1", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$orderedDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$deliveryDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$deliveryDate", "$orderedDate")), 86400000)),
-                                null)))
-                        .append("d2", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$deliveryDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$reviewSubmitDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$reviewSubmitDate", "$deliveryDate")), 86400000)),
-                                null)))
-                        .append("d3", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$reviewSubmitDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$reviewAcceptedDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$reviewAcceptedDate", "$reviewSubmitDate")), 86400000)),
-                                null)))
-                        .append("d4", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$deliveryDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$ratingSubmittedDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$ratingSubmittedDate", "$deliveryDate")), 86400000)),
-                                null)))
-                        .append("d5", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$reviewSubmitDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$refundFormSubmittedDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$refundFormSubmittedDate", "$reviewSubmitDate")), 86400000)),
-                                null)))
-                        .append("d6", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$ratingSubmittedDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$refundFormSubmittedDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$refundFormSubmittedDate", "$ratingSubmittedDate")), 86400000)),
-                                null)))
-                        .append("d7", new org.bson.Document("$cond", java.util.Arrays.asList(
-                                new org.bson.Document("$and", java.util.Arrays.asList(new org.bson.Document("$ne", java.util.Arrays.asList("$refundFormSubmittedDate", null)), new org.bson.Document("$ne", java.util.Arrays.asList("$paymentReceivedDate", null)))),
-                                new org.bson.Document("$divide", java.util.Arrays.asList(new org.bson.Document("$subtract", java.util.Arrays.asList("$paymentReceivedDate", "$refundFormSubmittedDate")), 86400000)),
-                                null)))
-                ),
-                new org.bson.Document("$group", new org.bson.Document("_id", null)
-                        .append("avg1", new org.bson.Document("$avg", "$d1"))
-                        .append("avg2", new org.bson.Document("$avg", "$d2"))
-                        .append("avg3", new org.bson.Document("$avg", "$d3"))
-                        .append("avg4", new org.bson.Document("$avg", "$d4"))
-                        .append("avg5", new org.bson.Document("$avg", "$d5"))
-                        .append("avg6", new org.bson.Document("$avg", "$d6"))
-                        .append("avg7", new org.bson.Document("$avg", "$d7"))
-                )
-        ));
-
-        ops.add(context -> new org.bson.Document("$facet", facet));
-
-        // Apply date range: if provided and scope==received, use paymentReceivedDate; else use createdAt
-        if (from != null || to != null) {
-            java.util.Date fromD = null, toD = null;
-            if (from != null) fromD = java.util.Date.from(from.atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-            if (to != null) toD = java.util.Date.from(to.plusDays(1).atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-            org.bson.Document cond = new org.bson.Document();
-            String field = ("received".equalsIgnoreCase(scope)) ? "paymentReceivedDate" : "createdAt";
-            org.bson.Document range = new org.bson.Document();
-            if (fromD != null) range.append("$gte", fromD);
-            if (toD != null) range.append("$lt", toD);
-            cond.append(field, range);
-            ops.add(context -> new org.bson.Document("$match", cond));
-        }
-
-        Aggregation agg = Aggregation.newAggregation(ops);
-        org.bson.Document root = mongoTemplate.aggregate(agg, Review.class, org.bson.Document.class)
-                .getUniqueMappedResult();
-        java.util.Map<String, Object> out = new java.util.HashMap<>();
-        if (root == null) return out;
-
-        java.util.List<org.bson.Document> totals = (java.util.List<org.bson.Document>) root.get("totals");
-        if (totals != null && !totals.isEmpty()) {
-            org.bson.Document t = totals.get(0);
-            // Normalize numeric types for the API (avoid Decimal128 leaking to JSON)
-            Object tr = t.get("totalReviews");
-            Object tpr = t.get("totalPaymentReceived");
-            Object ar = t.get("averageRefund");
-            Object ppa = t.get("paymentPendingAmount");
-            Object rs = t.get("reviewsSubmitted");
-            Object rp = t.get("reviewsPending");
-            out.put("totalReviews", (tr instanceof Number n) ? n.longValue() : 0L);
-            out.put("totalPaymentReceived", (tpr instanceof Number n) ? n.doubleValue() : 0.0);
-            out.put("averageRefund", (ar instanceof Number n) ? n.doubleValue() : 0.0);
-            out.put("paymentPendingAmount", (ppa instanceof Number n) ? n.doubleValue() : 0.0);
-            out.put("reviewsSubmitted", (rs instanceof Number n) ? n.longValue() : 0L);
-            out.put("reviewsPending", (rp instanceof Number n) ? n.longValue() : 0L);
-        }
-        out.put("statusCounts", toCountMap((java.util.List<org.bson.Document>) root.get("statusCounts")));
-        out.put("platformCounts", toCountMap((java.util.List<org.bson.Document>) root.get("platformCounts")));
-        out.put("dealTypeCounts", toCountMap((java.util.List<org.bson.Document>) root.get("dealTypeCounts")));
-        out.put("mediatorCounts", toCountMap((java.util.List<org.bson.Document>) root.get("mediatorCounts")));
-        out.put("amountReceivedByPlatform", toAmountMap((java.util.List<org.bson.Document>) root.get("receivedByPlatform"), "amt"));
-        out.put("amountPendingByPlatform", toAmountMap((java.util.List<org.bson.Document>) root.get("pendingByPlatform"), "amt"));
-        out.put("amountReceivedByMediator", toAmountMap((java.util.List<org.bson.Document>) root.get("receivedByMediator"), "amt"));
-        out.put("amountPendingByMediator", toAmountMap((java.util.List<org.bson.Document>) root.get("pendingByMediator"), "amt"));
-
-        java.util.List<org.bson.Document> overdue = (java.util.List<org.bson.Document>) root.get("overdue");
-        long ov = 0;
-        if (overdue != null && !overdue.isEmpty()) {
-            Object v = overdue.get(0).get("count");
-            if (v instanceof Number n) ov = n.longValue();
-        }
-        out.put("overdueSinceDeliveryCount", ov);
-
-        // agingBuckets removed
-
-        // avgStageDurations removed
-
-        // reviewsPending should equal delivered count
-        try {
-            java.util.Map<String, Long> sc = (java.util.Map<String, Long>) out.get("statusCounts");
-            long delivered = sc != null && sc.get("delivered") != null ? sc.get("delivered") : 0L;
-            out.put("reviewsPending", delivered);
-        } catch (Exception ignore) { }
-        return out;
-    }
-
-    private static java.util.Map<String, Long> toCountMap(java.util.List<org.bson.Document> rows) {
-        java.util.Map<String, Long> m = new java.util.HashMap<>();
-        if (rows == null) return m;
-        for (org.bson.Document d : rows) {
-            String k = String.valueOf(d.get("_id"));
-            m.put(k, ((Number) d.get("c")).longValue());
-        }
-        return m;
-    }
-
-    private static java.util.Map<String, java.math.BigDecimal> toAmountMap(java.util.List<org.bson.Document> rows, String field) {
-        java.util.Map<String, java.math.BigDecimal> m = new java.util.HashMap<>();
-        if (rows == null) return m;
-        for (org.bson.Document d : rows) {
-            String k = String.valueOf(d.get("_id"));
-            Object v = d.get(field);
-            java.math.BigDecimal bd;
-            if (v instanceof org.bson.types.Decimal128 dec) bd = dec.bigDecimalValue();
-            else if (v instanceof Number n) bd = java.math.BigDecimal.valueOf(n.doubleValue());
-            else bd = java.math.BigDecimal.ZERO;
-            m.put(k, bd);
-        }
-        return m;
-    }
-
-    private static Double toDouble(Object v) {
-        if (v == null) return 0.0;
-        if (v instanceof Number n) return n.doubleValue();
-        return 0.0;
-    }
-
-    @Override
-    public java.util.Map<String, Object> amountByPlatform() {
-        return amountByField("platformId", null, null, null);
-    }
-
-    @Override
-    public java.util.Map<String, Object> amountByMediator() {
-        return amountByField("mediatorId", null, null, null);
-    }
-
-    @Override
-    public java.util.Map<String, Object> amountByPlatform(String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        return amountByField("platformId", scope, from, to);
-    }
-
-    @Override
-    public java.util.Map<String, Object> amountByMediator(String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        return amountByField("mediatorId", scope, from, to);
-    }
-
-    private java.util.Map<String, Object> amountByField(String field, String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        java.util.List<AggregationOperation> ops = new java.util.ArrayList<>();
-        // computedRefund = refundAmountRupees ?? ((amountRupees && lessRupees) ? amountRupees-lessRupees : 0)
-        org.bson.Document amountAndLessPresent2 = new org.bson.Document("$and", java.util.Arrays.asList(
-                new org.bson.Document("$ne", java.util.Arrays.asList("$amountRupees", null)),
-                new org.bson.Document("$ne", java.util.Arrays.asList("$lessRupees", null))
-        ));
-        org.bson.Document fallbackSubtract2 = new org.bson.Document("$cond",
-                java.util.Arrays.asList(
-                        amountAndLessPresent2,
-                        new org.bson.Document("$subtract", java.util.Arrays.asList("$amountRupees", "$lessRupees")),
-                        0
-                )
-        );
-        org.bson.Document computedRefundExpr = new org.bson.Document("$ifNull",
-                java.util.Arrays.asList("$refundAmountRupees", fallbackSubtract2)
-        );
-        ops.add(context -> new org.bson.Document("$addFields", new org.bson.Document("computedRefund", computedRefundExpr)));
-
-        java.util.Date fromD = null, toD = null;
-        if (from != null) fromD = java.util.Date.from(from.atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-        if (to != null) toD = java.util.Date.from(to.plusDays(1).atStartOfDay(java.time.ZoneId.systemDefault()).toInstant());
-
-        org.bson.Document facet = new org.bson.Document();
-        // Received facet with optional date window on paymentReceivedDate
-        {
-            org.bson.Document match = new org.bson.Document("paymentReceivedDate", new org.bson.Document("$ne", null));
-            if (fromD != null || toD != null) {
-                org.bson.Document range = new org.bson.Document();
-                if (fromD != null) range.append("$gte", fromD);
-                if (toD != null) range.append("$lt", toD);
-                match.append("paymentReceivedDate", new org.bson.Document("$ne", null).append("$gte", range.get("$gte")).append("$lt", range.get("$lt")));
+        for (Review r : list) {
+            if (r.getAmountRupees() != null) totalAmount = totalAmount.add(r.getAmountRupees());
+            BigDecimal refund = r.getRefundAmountRupees();
+            if (refund == null) {
+                if (r.getAmountRupees() != null && r.getLessRupees() != null) {
+                    refund = r.getAmountRupees().subtract(r.getLessRupees());
+                }
             }
-            facet.append("received", java.util.List.of(
-                    new org.bson.Document("$match", match),
-                    new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$" + field, "unknown")))
-                            .append("amt", new org.bson.Document("$sum", new org.bson.Document("$ifNull", java.util.List.of("$refundAmountRupees", "$computedRefund")))))
-            ));
-        }
-        // Pending facet with optional date window on createdAt
-        {
-            org.bson.Document match = new org.bson.Document("paymentReceivedDate", null);
-            if (fromD != null || toD != null) {
-                org.bson.Document range = new org.bson.Document();
-                if (fromD != null) range.append("$gte", fromD);
-                if (toD != null) range.append("$lt", toD);
-                match.append("createdAt", range);
-            }
-            facet.append("pending", java.util.List.of(
-                    new org.bson.Document("$match", match),
-                    new org.bson.Document("$group", new org.bson.Document("_id", new org.bson.Document("$ifNull", java.util.List.of("$" + field, "unknown")))
-                            .append("amt", new org.bson.Document("$sum", "$computedRefund")))
-            ));
+            if (refund != null) totalRefund = totalRefund.add(refund);
         }
 
-        ops.add(context -> new org.bson.Document("$facet", facet));
-        Aggregation agg = Aggregation.newAggregation(ops);
-        org.bson.Document root = mongoTemplate.aggregate(agg, Review.class, org.bson.Document.class)
-                .getUniqueMappedResult();
-        if (root == null) {
-            java.util.Map<String, Object> empty = new java.util.HashMap<>();
-            empty.put("amountReceived", java.util.Collections.emptyMap());
-            empty.put("amountPending", java.util.Collections.emptyMap());
-            return empty;
-        }
-        java.util.Map<String, Object> out = new java.util.HashMap<>();
-        out.put("amountReceived", toAmountMap((java.util.List<org.bson.Document>) root.get("received"), "amt"));
-        out.put("amountPending", toAmountMap((java.util.List<org.bson.Document>) root.get("pending"), "amt"));
-        return out;
+        return java.util.Map.of(
+                "count", count,
+                "totalAmount", totalAmount.doubleValue(),
+                "totalRefund", totalRefund.doubleValue()
+        );
     }
 }
+

--- a/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/service/ReviewService.java
+++ b/review-tracker-backend/src/main/java/com/vinishchoudhary/reviewtracker/service/ReviewService.java
@@ -101,6 +101,12 @@ public class ReviewService {
         return reviewRepo.aggregatedTotals(criteria);
     }
 
+    // ---------- Metrics (MVP) ----------
+    public long overdueCount() {
+        java.time.LocalDate threshold = java.time.LocalDate.now().minusDays(7);
+        return reviewRepo.countByDeliveryDateBeforeAndPaymentReceivedDateIsNull(threshold);
+    }
+
     // ---------- Advance ----------
     public Review advanceNext(String id, LocalDate date) {
         Review r = reviewRepo.findById(id).orElseThrow();
@@ -414,43 +420,7 @@ public class ReviewService {
         try { return java.time.LocalDate.parse(s.trim()); } catch (Exception e) { return null; }
     }
 
-    // ---------- Dashboard ----------
-    public Map<String, Object> dashboard(String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        return reviewRepo.aggregatedDashboard(scope, from, to);
-    }
-
-    public Map<String, Object> amountsByPlatform() {
-        Map<String, Object> r = reviewRepo.amountByPlatform();
-        // Normalize keys to match previous dashboard shape when needed
-        Map<String, Object> out = new HashMap<>();
-        out.put("amountReceivedByPlatform", r.get("amountReceived"));
-        out.put("amountPendingByPlatform", r.get("amountPending"));
-        return out;
-    }
-
-    public Map<String, Object> amountsByMediator() {
-        Map<String, Object> r = reviewRepo.amountByMediator();
-        Map<String, Object> out = new HashMap<>();
-        out.put("amountReceivedByMediator", r.get("amountReceived"));
-        out.put("amountPendingByMediator", r.get("amountPending"));
-        return out;
-    }
-
-    public Map<String, Object> amountsByPlatform(String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        Map<String, Object> r = reviewRepo.amountByPlatform(scope, from, to);
-        Map<String, Object> out = new HashMap<>();
-        out.put("amountReceivedByPlatform", r.get("amountReceived"));
-        out.put("amountPendingByPlatform", r.get("amountPending"));
-        return out;
-    }
-
-    public Map<String, Object> amountsByMediator(String scope, java.time.LocalDate from, java.time.LocalDate to) {
-        Map<String, Object> r = reviewRepo.amountByMediator(scope, from, to);
-        Map<String, Object> out = new HashMap<>();
-        out.put("amountReceivedByMediator", r.get("amountReceived"));
-        out.put("amountPendingByMediator", r.get("amountPending"));
-        return out;
-    }
+    // Dashboard and related stats removed for redesign
 
     private static long diffDays(java.time.LocalDate from, java.time.LocalDate to) {
         return java.time.temporal.ChronoUnit.DAYS.between(from, to);

--- a/review-tracker-ui/src/App.jsx
+++ b/review-tracker-ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Link, Navigate } from "react-router-dom";
 import { useState } from "react";
 import ToastProvider from "./components/ToastProvider";
 import Dashboard from "./pages/Dashboard";
@@ -41,7 +41,7 @@ function App() {
                   ✕
                 </button>
               </div>
-              <Link to="/" className="block hover:text-gray-300" onClick={() => setMobileNavOpen(false)}>Dashboard</Link>
+              <Link to="/dashboard" className="block hover:text-gray-300" onClick={() => setMobileNavOpen(false)}>Dashboard</Link>
               <Link to="/reviews" className="block hover:text-gray-300" onClick={() => setMobileNavOpen(false)}>Reviews</Link>
               <Link to="/lookups" className="block hover:text-gray-300" onClick={() => setMobileNavOpen(false)}>Lookups</Link>
               <Link to="/archive" className="block hover:text-gray-300" onClick={() => setMobileNavOpen(false)}>Archive</Link>
@@ -53,7 +53,7 @@ function App() {
           {/* Sidebar (desktop) */}
           <nav className="hidden md:block w-60 bg-gray-800 text-white p-4 space-y-4">
             <h1 className="text-xl font-bold">Review Tracker</h1>
-            <Link to="/" className="block hover:text-gray-300">Dashboard</Link>
+            <Link to="/dashboard" className="block hover:text-gray-300">Dashboard</Link>
             <Link to="/reviews" className="block hover:text-gray-300">Reviews</Link>
             <Link to="/lookups" className="block hover:text-gray-300">Lookups</Link>
             <Link to="/archive" className="block hover:text-gray-300">Archive</Link>
@@ -62,7 +62,8 @@ function App() {
           {/* Main Content */}
           <main className="flex-1 p-4 md:p-6 md:overflow-y-auto pt-12 md:pt-0">
             <Routes>
-              <Route path="/" element={<Dashboard />} />
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/reviews/*" element={<Reviews />} />
               <Route path="/lookups" element={<Lookups />} />
               <Route path="/archive" element={<Archive />} />

--- a/review-tracker-ui/src/api/reviews.js
+++ b/review-tracker-ui/src/api/reviews.js
@@ -29,6 +29,7 @@ export const importCsv = (file) => {
 };
 export const bulkDelete = (ids) => axios.post(`${API_BASE}/bulk-delete`, ids);
 export const aggregates = (criteria) => axios.get(`${API_BASE}/aggregates`, { params: toQuery(criteria) });
+export const overdueCount = () => axios.get(`${API_BASE}/metrics/overdue-count`);
 
 // Advance next step endpoints
 export const advanceReview = (id, date) => axios.post(`${API_BASE}/${id}/advance`, { date });

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -1,364 +1,90 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { aggregates as apiAggregates, searchReviews, overdueCount as apiOverdueCount } from "../api/reviews";
 import { formatCurrencyINR as formatCurrency, formatInt } from "../utils/format";
-import axios from "axios";
-import { getPlatforms, getMediators } from "../api/lookups";
-import { useNavigate } from "react-router-dom";
 
 export default function Dashboard() {
-  const [data, setData] = useState(null);
-  const [platformMap, setPlatformMap] = useState({});
-  const [mediatorMap, setMediatorMap] = useState({});
-  const [platAmts, setPlatAmts] = useState(null);
-  const [medAmts, setMedAmts] = useState(null);
-  const [topN, setTopN] = useState(8); // collapse long tails into "Others"
-  const [countMode, setCountMode] = useState('count'); // 'count' | 'percent'
-  const navigate = useNavigate();
-  const [scope, setScope] = useState('all'); // 'all' | 'received' | 'pending'
-  const [from, setFrom] = useState('');
-  const [to, setTo] = useState('');
+  const [totals, setTotals] = useState({ count: 0, totalAmount: 0, totalRefund: 0 });
+  const [counts, setCounts] = useState({
+    pendingReviewRating: null,
+    pendingRefundForm: null,
+    pendingPayment: null,
+    overdue: null,
+  });
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    Promise.all([getPlatforms(), getMediators()]).then(([p, m]) => {
-      setPlatformMap(Object.fromEntries((p.data||[]).map(x=>[x.id, x.name])));
-      setMediatorMap(Object.fromEntries((m.data||[]).map(x=>[x.id, x.name])));
-    });
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const [aggRes, c1, c2, c3, oc] = await Promise.all([
+          apiAggregates({}),
+          // Use search endpoint to fetch counts via totalElements (request minimal page size)
+          searchReviews({ statusIn: ["ordered", "delivered"] }, { page: 0, size: 1, sort: "createdAt", dir: "DESC" }),
+          searchReviews({ statusIn: ["review submitted", "review accepted", "rating submitted"] }, { page: 0, size: 1, sort: "createdAt", dir: "DESC" }),
+          searchReviews({ statusIn: ["refund form submitted"] }, { page: 0, size: 1, sort: "createdAt", dir: "DESC" }),
+          apiOverdueCount(),
+        ]);
+        if (cancelled) return;
+        setTotals({
+          count: Number(aggRes.data?.count ?? 0),
+          totalAmount: Number(aggRes.data?.totalAmount ?? 0),
+          totalRefund: Number(aggRes.data?.totalRefund ?? 0),
+        });
+        setCounts({
+          pendingReviewRating: Number(c1.data?.totalElements ?? 0),
+          pendingRefundForm: Number(c2.data?.totalElements ?? 0),
+          pendingPayment: Number(c3.data?.totalElements ?? 0),
+          overdue: Number(oc.data?.overdue ?? 0),
+        });
+      } catch (e) {
+        // Soft-fail: keep UI visible with zeros
+        setCounts({ pendingReviewRating: null, pendingRefundForm: null, pendingPayment: null, overdue: null });
+      }
+      setLoading(false);
+    }
+    load();
+    return () => { cancelled = true; };
   }, []);
 
-  // Load persisted dashboard controls
-  useEffect(() => {
-    try {
-      const s = localStorage.getItem('dash-scope'); if (s) setScope(s);
-      const f = localStorage.getItem('dash-from'); if (f) setFrom(f);
-      const t = localStorage.getItem('dash-to'); if (t) setTo(t);
-      const cm = localStorage.getItem('dash-count-mode'); if (cm) setCountMode(cm);
-      const tn = localStorage.getItem('dash-top-n'); if (tn) setTopN(Number(tn));
-    } catch { /* noop */ }
-  }, []);
+  const Card = ({ title, value, to, accent = "indigo" }) => (
+    <Link to={to} className={`block rounded-lg border p-4 hover:shadow transition bg-white border-${accent}-100`}>
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="mt-1 text-2xl font-semibold">{value == null ? "—" : formatInt(value)}</div>
+      <div className={`mt-2 text-xs text-${accent}-700`}>View details →</div>
+    </Link>
+  );
 
-  // Persist controls when changed
-  useEffect(() => { try { localStorage.setItem('dash-scope', scope); } catch { /* noop */ } }, [scope]);
-  useEffect(() => { try { from ? localStorage.setItem('dash-from', from) : localStorage.removeItem('dash-from'); } catch { /* noop */ } }, [from]);
-  useEffect(() => { try { to ? localStorage.setItem('dash-to', to) : localStorage.removeItem('dash-to'); } catch { /* noop */ } }, [to]);
-  useEffect(() => { try { localStorage.setItem('dash-count-mode', countMode); } catch { /* noop */ } }, [countMode]);
-  useEffect(() => { try { localStorage.setItem('dash-top-n', String(topN)); } catch { /* noop */ } }, [topN]);
-
-  useEffect(() => {
-    const params = {};
-    if (scope && scope !== 'all') params.scope = scope;
-    if (from) params.from = from;
-    if (to) params.to = to;
-    axios.get("/api/reviews/dashboard", { params }).then(res => setData(res.data));
-    axios.get("/api/reviews/stats/amounts/platform", { params }).then(res => setPlatAmts(res.data)).catch(()=>{});
-    axios.get("/api/reviews/stats/amounts/mediator", { params }).then(res => setMedAmts(res.data)).catch(()=>{});
-  }, [scope, from, to]);
-
-  const d = data || { statusCounts: {}, platformCounts: {}, dealTypeCounts: {}, mediatorCounts: {} };
-  const statusEntries = Object.entries(d.statusCounts || {});
-  const platformEntriesRaw = useMemo(() => Object.entries(d.platformCounts || {})
-    .map(([id,c]) => [platformMap[id] || id, c])
-    .sort((a,b) => b[1]-a[1])
-  , [d.platformCounts, platformMap]);
-  const dealEntriesRaw = useMemo(() => Object.entries(d.dealTypeCounts || {})
-    .map(([code,c]) => [dealTypeLabel(code), c])
-    .sort((a,b) => b[1]-a[1])
-  , [d.dealTypeCounts]);
-  const mediatorEntriesRaw = useMemo(() => Object.entries(d.mediatorCounts || {})
-    .map(([id,c]) => [mediatorMap[id] || id, c])
-    .sort((a,b) => b[1]-a[1])
-  , [d.mediatorCounts, mediatorMap]);
-
-  const applyTop = useCallback((entries) => {
-    if (!Array.isArray(entries)) return [];
-    if (!topN || entries.length <= topN) return entries;
-    const keep = Math.max(1, topN - 1);
-    const head = entries.slice(0, keep);
-    const others = entries.slice(keep).reduce((s, [,v]) => s + (Number(v)||0), 0);
-    return [...head, ['Others', others]];
-  }, [topN]);
-
-  const platformEntries = useMemo(() => applyTop(platformEntriesRaw), [platformEntriesRaw, applyTop]);
-  // Deal types are only three – no need for Top-N collapse
-  const dealEntries = useMemo(() => dealEntriesRaw, [dealEntriesRaw]);
-  const mediatorEntries = useMemo(() => applyTop(mediatorEntriesRaw), [mediatorEntriesRaw, applyTop]);
-
-  const donutColors = {
-    'ordered': '#94a3b8',
-    'delivered': '#38bdf8',
-    'review submitted': '#f59e0b',
-    'review accepted': '#22c55e',
-    'rating submitted': '#a78bfa',
-    'refund form submitted': '#f97316',
-    'payment received': '#10b981',
-    'unknown': '#e5e7eb'
-  };
-  const donut = (() => {
-    const totalStatus = statusEntries.reduce((s, [,v]) => s + v, 0) || 1;
-    let acc = 0;
-    const donutStops = statusEntries.map(([k,v]) => {
-      const start = (acc/totalStatus)*100; acc += v; const end = (acc/totalStatus)*100;
-      const color = donutColors[k] || '#999';
-      return `${color} ${start}% ${end}%`;
-    });
-    return { style: { background: `conic-gradient(${donutStops.join(',')})` }, legend: Object.fromEntries(statusEntries.map(([k])=>[k, donutColors[k]||'#999'])) };
-  })();
+  const Stat = ({ label, value, fmt = (v)=>v }) => (
+    <div className="rounded-lg border bg-white p-4">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="mt-1 text-xl font-semibold">{fmt(value)}</div>
+    </div>
+  );
 
   return (
-    <div className="space-y-6 text-gray-900">
-      {/* Hero Section */}
-      <div className="p-6 rounded-b-xl bg-white border-b">
-        <h2 className="text-3xl font-bold text-gray-900">Dashboard</h2>
-        <p className="text-gray-600">A quick overview of your review operations</p>
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">Dashboard</h2>
       </div>
-      {/* Controls */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="text-xs text-gray-600 inline-flex items-center gap-2">
-          <span>Scope:</span>
-          {['all','received','pending'].map(s => (
-            <button key={s} className={`px-2 py-0.5 border rounded capitalize ${scope===s?'bg-gray-100 border-gray-300':'border-transparent hover:bg-gray-50'}`} onClick={()=> setScope(s)}>{s}</button>
-          ))}
-          <span className="ml-2">From</span>
-          <input type="date" className="border rounded px-2 py-0.5 bg-white text-gray-900" value={from} onChange={e=> setFrom(e.target.value)} />
-          <span>To</span>
-          <input type="date" className="border rounded px-2 py-0.5 bg-white text-gray-900" value={to} onChange={e=> setTo(e.target.value)} />
-          <button className="px-2 py-0.5 border rounded hover:bg-gray-50" onClick={()=> { setFrom(''); setTo(''); }}>Clear</button>
-        </div>
-        <div className="text-xs text-gray-600 inline-flex items-center gap-1">
-          <span>Counts:</span>
-          <button className={`px-2 py-0.5 border rounded ${countMode==='count'?'bg-gray-100 border-gray-300':'border-transparent hover:bg-gray-50'}`} onClick={()=> setCountMode('count')}>Count</button>
-          <button className={`px-2 py-0.5 border rounded ${countMode==='percent'?'bg-gray-100 border-gray-300':'border-transparent hover:bg-gray-50'}`} onClick={()=> setCountMode('percent')}>%</button>
-        </div>
-      </div>
-      {/* Controls */}
-      <div className="flex flex-wrap items-center justify-end gap-3">
-        <div className="text-xs text-gray-600 inline-flex items-center gap-1">
-          <span>Counts:</span>
-          <button className={`px-2 py-0.5 border rounded ${countMode==='count'?'bg-gray-100 border-gray-300':'border-transparent hover:bg-gray-50'}`} onClick={()=> setCountMode('count')}>Count</button>
-          <button className={`px-2 py-0.5 border rounded ${countMode==='percent'?'bg-gray-100 border-gray-300':'border-transparent hover:bg-gray-50'}`} onClick={()=> setCountMode('percent')}>%</button>
-        </div>
-      </div>
-      {(!data) ? (
-        <div className="space-y-4 animate-pulse">
-          <div className="grid grid-cols-7 gap-4">
-            {Array.from({length:7}).map((_,i)=> (
-              <div key={i} className="bg-white/90 ring-1 ring-gray-100 shadow-sm p-4 rounded-lg">
-                <div className="h-3 w-24 bg-gray-200 rounded mb-2" />
-                <div className="h-6 w-20 bg-gray-200 rounded" />
-              </div>
-            ))}
-          </div>
-          <div className="grid grid-cols-3 gap-4">
-            {Array.from({length:3}).map((_,i)=> (
-              <div key={i} className="bg-white shadow p-4 rounded">
-                <div className="h-4 w-40 bg-gray-200 rounded mb-3" />
-                <div className="flex items-center gap-4">
-                  <div className="w-24 h-24 rounded-full bg-gray-200" />
-                  <div className="space-y-2 w-full">
-                    {Array.from({length:4}).map((_,j)=> <div key={j} className="h-3 bg-gray-200 rounded" />)}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            {Array.from({length:4}).map((_,i)=> (
-              <div key={i} className="bg-white shadow p-4 rounded">
-                <div className="h-4 w-56 bg-gray-200 rounded mb-3" />
-                <div className="space-y-2">
-                  {Array.from({length:5}).map((_,j)=> <div key={j} className="h-2 bg-gray-200 rounded" />)}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : (
-        <>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-8 gap-4">
-            <Card title="Total Reviews" value={formatInt(data.totalReviews)} onClick={()=> navigate('/reviews')} clickable />
-            <Card title="Payment Received" value={formatCurrency(data.totalPaymentReceived)} onClick={()=> navigate('/archive')} clickable />
-            {/* Avg Refund removed */}
-            <Card title="Pending Review/Rating" value={formatInt(Number(data.statusCounts?.["ordered"]||0)+Number(data.statusCounts?.["delivered"]||0))} onClick={()=> navigate('/reviews?preset=pending-review-rating')} clickable />
-            <Card title="Pending Refund Form" value={formatInt(Number(data.statusCounts?.["review submitted"]||0)+Number(data.statusCounts?.["review accepted"]||0)+Number(data.statusCounts?.["rating submitted"]||0))} onClick={()=> navigate('/reviews?preset=pending-refund-form')} clickable />
-            <Card title="Pending Payment" value={formatInt(Number(data.statusCounts?.["refund form submitted"]||0))} onClick={()=> navigate('/reviews?preset=pending-payment')} clickable />
-            <Card title="Payment Pending Amt" value={formatCurrency(data.paymentPendingAmount)} />
-            <Card title=">7d Since Delivery" value={formatInt(data.overdueSinceDeliveryCount || 0)} onClick={()=> navigate('/reviews?preset=overdue')} clickable />
-          </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            <Panel title="By Status">
-              <div className="flex items-center gap-4">
-                <div className="w-28 h-28 md:w-32 md:h-32 rounded-full" style={donut.style} />
-                <List entries={statusEntries} legend={donut.legend} mode={countMode} />
-              </div>
-            </Panel>
-            <Panel title={TopTitle('Platforms (Count)', topN, setTopN)}>
-              <Pie entries={platformEntries} mode={countMode} />
-            </Panel>
-            <Panel title={'Deal Types (Count)'}>
-              <Pie entries={dealEntries} mode={countMode} />
-            </Panel>
-            <Panel title={TopTitle('Mediators (Count)', topN, setTopN)}>
-              <Pie entries={mediatorEntries} mode={countMode} />
-            </Panel>
-            {/* Aging and Stage Durations panels removed */}
-          </div>
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card title="Pending Review/Rating" value={counts.pendingReviewRating} to="/reviews?preset=pending-review-rating" accent="blue" />
+        <Card title="Pending Refund Form" value={counts.pendingRefundForm} to="/reviews?preset=pending-refund-form" accent="amber" />
+        <Card title="Pending Payment" value={counts.pendingPayment} to="/reviews?preset=pending-payment" accent="emerald" />
+        <Card title="Overdue" value={counts.overdue} to="/reviews?preset=overdue" accent="rose" />
+      </section>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <Panel title={TopTitle('Amount Received by Platform', topN, setTopN)}>
-              <BarCurrency entries={applyTop(Object.entries((platAmts?.amountReceivedByPlatform)||{}).map(([id,amt])=>[platformMap[id]||id, Number(amt)]))} />
-            </Panel>
-            <Panel title={TopTitle('Amount Pending by Platform', topN, setTopN)}>
-              <BarCurrency entries={applyTop(Object.entries((platAmts?.amountPendingByPlatform)||{}).map(([id,amt])=>[platformMap[id]||id, Number(amt)]))} />
-            </Panel>
-            <Panel title={TopTitle('Amount Received by Mediator', topN, setTopN)}>
-              <BarCurrency entries={applyTop(Object.entries((medAmts?.amountReceivedByMediator)||{}).map(([id,amt])=>[mediatorMap[id]||id, Number(amt)]))} />
-            </Panel>
-            <Panel title={TopTitle('Amount Pending by Mediator', topN, setTopN)}>
-              <BarCurrency entries={applyTop(Object.entries((medAmts?.amountPendingByMediator)||{}).map(([id,amt])=>[mediatorMap[id]||id, Number(amt)]))} />
-            </Panel>
-          </div>
-        </>
+      <section className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Stat label="Total Reviews" value={totals.count} fmt={formatInt} />
+        <Stat label="Total Amount" value={totals.totalAmount} fmt={formatCurrency} />
+        <Stat label="Total Refund" value={totals.totalRefund} fmt={formatCurrency} />
+      </section>
+
+      {loading && (
+        <div className="text-sm text-gray-500">Loading metrics…</div>
       )}
     </div>
   );
-}
-
-function Card({ title, value, onClick, clickable }) {
-  return (
-    <div className={`bg-white/90 ring-1 ring-gray-100 shadow-sm p-4 rounded-lg ${clickable ? 'cursor-pointer hover:shadow-md transition' : ''}`} onClick={onClick}>
-      <div className="text-sm text-gray-500">{title}</div>
-      <div className="text-2xl font-semibold text-gray-900">{value}</div>
-    </div>
-  );
-}
-
-function Panel({ title, children }) {
-  return (
-    <div className="bg-white shadow p-4 rounded">
-      <div className="text-lg font-semibold mb-2">{title}</div>
-      {children}
-    </div>
-  );
-}
-
-function TopTitle(label, topN, setTopN) {
-  return (
-    <div className="flex items-center justify-between gap-2">
-      <span>{label}</span>
-      <div className="text-xs text-gray-600 hidden md:flex items-center gap-1">
-        <span>Top:</span>
-        {[5,8,12].map(n => (
-          <button key={n} className={`px-2 py-0.5 border rounded ${topN===n? 'bg-gray-100 border-gray-300' : 'border-transparent hover:bg-gray-50'}`} onClick={()=> setTopN(n)}>{n}</button>
-        ))}
-        <button className={`px-2 py-0.5 border rounded ${!topN? 'bg-gray-100 border-gray-300' : 'border-transparent hover:bg-gray-50'}`} onClick={()=> setTopN(0)}>All</button>
-      </div>
-    </div>
-  );
-}
-
-function List({ entries, legend, mode = 'count' }) {
-  if (!entries.length) return <div className="text-sm text-gray-500">No data</div>;
-  const total = entries.reduce((s, [,v]) => s + (Number(v)||0), 0) || 1;
-  return (
-    <ul className="space-y-1 text-sm">
-      {entries.map(([k, v]) => {
-        const n = Number(v)||0;
-        const pct = Math.round((n/total)*100);
-        const title = `${formatInt(n)} (${pct}%)`;
-        const display = mode==='percent' ? `${pct}%` : formatInt(n);
-        return (
-          <li key={k} className="flex justify-between items-center" title={title}>
-            <span className="capitalize inline-flex items-center gap-2">
-              {legend && <span className="inline-block w-3 h-3 rounded-sm" style={{background: legend[k]}} />}
-              {k}
-            </span>
-            <span className="font-medium">{display}</span>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-function Bars({ entries, mode = 'count' }) {
-  if (!entries.length) return <div className="text-sm text-gray-500">No data</div>;
-  const total = entries.reduce((s, [,v]) => s + (Number(v)||0), 0) || 1;
-  return (
-    <div className="space-y-2">
-      {entries.map(([k, v]) => {
-        const n = Number(v)||0;
-        const pct = Math.round((n/total)*100);
-        const label = mode==='percent' ? `${pct}%` : formatInt(n);
-        const title = `${formatInt(n)} (${pct}%)`;
-        return (
-          <div key={k} className="text-sm" title={title}>
-            <div className="flex justify-between"><span className="capitalize">{k}</span><span>{label}</span></div>
-            <div className="w-full h-2 bg-gray-200 rounded">
-              <div className="h-2 bg-blue-500 rounded" style={{ width: `${pct}%` }} />
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function KeyVals({ entries }) {
-  if (!entries.length) return <div className="text-sm text-gray-500">No data</div>;
-  return (
-    <ul className="space-y-1 text-sm">
-      {entries.map(([k, v]) => (
-        <li key={k} className="flex justify-between items-center">
-          <span className="capitalize">{k}</span>
-          <span className="font-medium">{v} d</span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-// Removed stage duration labels (panel removed)
-
-function Pie({ entries, mode = 'count' }) {
-  if (!entries.length) return <div className="text-sm text-gray-500">No data</div>;
-  const colors = ['#60a5fa','#34d399','#fbbf24','#f472b6','#a78bfa','#f87171','#10b981','#f59e0b','#22c55e','#ef4444','#06b6d4'];
-  const total = entries.reduce((s, [,v]) => s + (Number(v)||0), 0) || 1;
-  let acc = 0;
-  const stops = entries.map(([k,v],i)=>{ const n=Number(v)||0; const start=(acc/total)*100; acc+=n; const end=(acc/total)*100; const color=(k==='Others')? '#9ca3af' : colors[i%colors.length]; return `${color} ${start}% ${end}%`; });
-  const legend = Object.fromEntries(entries.map(([k],i)=>[k, (k==='Others')? '#9ca3af' : colors[i%colors.length]]));
-  return (
-    <div className="flex items-center gap-4">
-      <div className="w-28 h-28 md:w-32 md:h-32 rounded-full" style={{ background: `conic-gradient(${stops.join(',')})` }} />
-      <List entries={entries} legend={legend} mode={mode} />
-    </div>
-  );
-}
-
-function BarCurrency({ entries }) {
-  if (!entries.length) return <div className="text-sm text-gray-500">No data</div>;
-  const max = Math.max(...entries.map(([,v]) => v||0), 1);
-  return (
-    <div className="space-y-2">
-      {entries.sort((a,b)=> b[1]-a[1]).map(([k, v]) => {
-        const pct = Math.round(((v||0)/max)*100);
-        return (
-          <div key={k} className="text-sm">
-            <div className="flex justify-between"><span className="capitalize">{k}</span><span>{formatCurrency(v||0)}</span></div>
-            <div className="w-full h-2 bg-gray-200 rounded">
-              <div className="h-2 bg-indigo-500 rounded" style={{ width: `${pct}%` }} />
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function dealTypeLabel(code) {
-  switch (code) {
-    case 'REVIEW_PUBLISHED': return 'Review Published';
-    case 'REVIEW_SUBMISSION': return 'Review Submission';
-    case 'RATING_ONLY': return 'Rating Only';
-    case 'unknown': return 'Unknown';
-    default: return code || '-';
-  }
 }

--- a/review-tracker-ui/src/pages/Dashboard.jsx
+++ b/review-tracker-ui/src/pages/Dashboard.jsx
@@ -38,8 +38,9 @@ export default function Dashboard() {
           pendingPayment: Number(c3.data?.totalElements ?? 0),
           overdue: Number(oc.data?.overdue ?? 0),
         });
-      } catch (e) {
+      } catch (err) {
         // Soft-fail: keep UI visible with zeros
+        console.error('Failed to load dashboard metrics', err);
         setCounts({ pendingReviewRating: null, pendingRefundForm: null, pendingPayment: null, overdue: null });
       }
       setLoading(false);


### PR DESCRIPTION
Summary
- Remove legacy dashboard endpoints and UI.
- Purge unused repository aggregations and helpers.
- Add overdue-count metric endpoint (delivered > 7 days ago and payment not received).
- Implement new Dashboard page with 4 action cards and 3 totals.
- Make Dashboard the default landing route.

Details
- API
  - Removed: /api/reviews/dashboard and related stats endpoints.
  - Added: GET /api/reviews/metrics/overdue-count -> { overdue } using derived query.
  - Kept: /api/reviews/aggregates for totals (count/totalAmount/totalRefund).
- Repository
  - Simplified ReviewRepositoryImpl to only implement searchReviews + aggregatedTotals.
  - Removed all dashboard/amount-by aggregation pipelines and helpers.
- UI
  - New page: src/pages/Dashboard.jsx with summary cards linking to filtered Reviews presets.
  - Added overdue metric to the Overdue card; totals from /aggregates.
  - Updated nav and routing; root (/) redirects to /dashboard.
- Tests
  - E2E test previously referenced the dashboard; that check was removed earlier. One CSV-import assertion is unrelated and may still be flaky; can follow-up.

Notes
- This is an MVP shell focused on meaningful, fast-first metrics; we can add scope/date filters and breakdown charts in a follow-up PR.
- No migration required; persists with current data.
